### PR TITLE
Add mock auth API and integrate with login screen

### DIFF
--- a/components/LoginScreen.tsx
+++ b/components/LoginScreen.tsx
@@ -9,6 +9,7 @@ import { useUserProfile } from './UserProfileContext';
 import { InputOTP, InputOTPGroup, InputOTPSlot } from './ui/input-otp';
 import { toast } from 'sonner';
 import { saveAuth } from '../utils/auth';
+import { apiClient } from '../utils/apiClient';
 
 interface LoginScreenProps {
   onLogin: (authData: any) => void;
@@ -88,7 +89,7 @@ export function LoginScreen({ onLogin, onShowRegister }: LoginScreenProps) {
     }
 
     try {
-      const response = await fetch('/api/auth/request-otp', {
+      await apiClient('/auth/request-otp', {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json'
@@ -97,10 +98,6 @@ export function LoginScreen({ onLogin, onShowRegister }: LoginScreenProps) {
           phone: `${selectedCountry?.phonePrefix}${phoneNumber}`
         })
       });
-      const data = await response.json();
-      if (!response.ok) {
-        throw new Error(data.error || 'Failed to send code');
-      }
       setCodeSent(true);
     } catch (error: any) {
       console.error('OTP request error:', error);
@@ -115,7 +112,7 @@ export function LoginScreen({ onLogin, onShowRegister }: LoginScreenProps) {
     setIsVerifying(true);
     setError('');
     try {
-      const response = await fetch('/api/auth/verify-otp', {
+      const data = await apiClient('/auth/verify-otp', {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json'
@@ -125,10 +122,6 @@ export function LoginScreen({ onLogin, onShowRegister }: LoginScreenProps) {
           otp
         })
       });
-      const data = await response.json();
-      if (!response.ok) {
-        throw new Error(data.error || 'OTP verification failed');
-      }
       saveAuth({ auth: { token: data.token }, user: data.user });
       onLogin({ token: data.token, user: data.user });
     } catch (error: any) {

--- a/mocks/auth.ts
+++ b/mocks/auth.ts
@@ -1,0 +1,21 @@
+export async function handle(path: string, init?: RequestInit) {
+  const body = typeof init?.body === 'string' ? init.body : undefined;
+  const data = body ? JSON.parse(body) : {};
+
+  if (path === '/auth/request-otp') {
+    return { message: 'OTP sent' };
+  }
+
+  if (path === '/auth/verify-otp') {
+    return {
+      token: 'mock-token',
+      user: {
+        id: 'demo-user',
+        name: 'Demo User',
+        phone: data.phone,
+      },
+    };
+  }
+
+  throw new Error(`No mock handler for path: ${path}`);
+}

--- a/utils/apiClient.ts
+++ b/utils/apiClient.ts
@@ -4,6 +4,7 @@ import { handle as mockGroups } from '../mocks/groups';
 import { handle as mockUpcomingPayments } from '../mocks/upcoming-payments';
 import { handle as mockContacts } from '../mocks/contacts';
 import { handle as mockRequests } from '../mocks/requests';
+import { handle as mockAuth } from '../mocks/auth';
 
 type MockHandler = (path: string, init?: RequestInit) => Promise<any>;
 
@@ -13,6 +14,7 @@ const mockRoutes: Array<{ test: RegExp; handler: MockHandler }> = [
   { test: /^\/upcoming-payments/, handler: mockUpcomingPayments },
   { test: /^\/contacts\/match/, handler: mockContacts },
   { test: /^\/requests/, handler: mockRequests },
+  { test: /^\/auth/, handler: mockAuth },
 ];
 
 export async function apiClient(


### PR DESCRIPTION
## Summary
- add auth mock to simulate OTP request and verification
- register auth mock with apiClient
- switch LoginScreen to use apiClient for auth OTP flows

## Testing
- `npm install`
- `npm test` (fails: @prisma/client did not initialize yet)


------
https://chatgpt.com/codex/tasks/task_e_68ac4e42b7248323adfaabe2c02297b6