### PR TITLE
Handle null user profile in ProfileScreen

### DIFF
--- a/components/ProfileScreen.tsx
+++ b/components/ProfileScreen.tsx
@@ -33,12 +33,24 @@ interface ProfileScreenProps {
 
 export function ProfileScreen({ onNavigate, onLogout }: ProfileScreenProps) {
   const { userProfile, updateUserProfile, refreshUserProfile } = useUserProfile();
-  const [preferences, setPreferences] = useState(userProfile.preferences);
+  const defaultPreferences = {
+    notifications: false,
+    emailAlerts: false,
+    whatsappAlerts: false,
+    darkMode: false,
+    biometrics: false,
+    notificationSettings: {},
+  };
+  const [preferences, setPreferences] = useState(
+    userProfile?.preferences ?? defaultPreferences,
+  );
   const [isLoading, setIsLoading] = useState(true);
 
   useEffect(() => {
-    setPreferences(userProfile.preferences);
-  }, [userProfile.preferences]);
+    if (userProfile?.preferences) {
+      setPreferences(userProfile.preferences);
+    }
+  }, [userProfile]);
 
   const hasLoaded = useRef(false);
 
@@ -91,6 +103,10 @@ export function ProfileScreen({ onNavigate, onLogout }: ProfileScreenProps) {
       ],
     },
   ];
+
+  if (!userProfile) {
+    return isLoading ? <ProfileSkeleton /> : <div>Error loading profile</div>;
+  }
 
   return (
     <div className="pb-20">


### PR DESCRIPTION
## Summary
- Default profile preferences when user data is absent
- Safely update preferences only when a profile is available
- Render skeleton or error message if the profile fails to load

## Testing
- `npm test` *(fails: GroupMembersScreen and GroupAccountScreen tests)*

------
https://chatgpt.com/codex/tasks/task_e_68ac5961ed848323b3448b74c0161520