### PR TITLE
Validate JWT structure before verification

### DIFF
--- a/server/middleware/auth.js
+++ b/server/middleware/auth.js
@@ -34,6 +34,10 @@ export default async function authenticate(req, res, next) {
 
   const token = parts[1]
 
+  if (token.split('.').length !== 3) {
+    return res.status(401).json({ error: 'Malformed token' })
+  }
+
   try {
     const decoded = jwt.verify(token, JWT_SECRET)
     const user = await req.prisma.user.findUnique({


### PR DESCRIPTION
## Summary
- ensure auth middleware rejects JWTs without three segments

## Testing
- `npm test` (fails: Missing prisma generation and test failures)
- `npm run lint` (fails: 79 errors, 201 warnings)


------
https://chatgpt.com/codex/tasks/task_e_68ac61eab27483239966f18eb9f5c0de