### PR TITLE
Log JWT token and verify auth header

### DIFF
--- a/utils/apiClient.test.ts
+++ b/utils/apiClient.test.ts
@@ -1,0 +1,42 @@
+import { describe, beforeEach, it, expect, vi } from 'vitest';
+
+vi.mock('./config', () => ({
+  apiBaseUrl: 'http://example.com',
+  useMockApi: false,
+}));
+
+import { apiClient } from './apiClient';
+
+describe('apiClient', () => {
+  beforeEach(() => {
+    const store: Record<string, string> = {};
+    // simple in-memory localStorage mock
+    globalThis.localStorage = {
+      getItem: (key: string) => (key in store ? store[key] : null),
+      setItem: (key: string, value: string) => { store[key] = value; },
+      removeItem: (key: string) => { delete store[key]; },
+      clear: () => { for (const k in store) delete store[k]; },
+      key: (index: number) => Object.keys(store)[index] ?? null,
+      get length() { return Object.keys(store).length; },
+    } as unknown as Storage;
+
+    globalThis.fetch = vi.fn(() => Promise.resolve({
+      ok: true,
+      json: () => Promise.resolve({}),
+    })) as unknown as typeof fetch;
+  });
+
+  it('appends Authorization header when token is a valid JWT', async () => {
+    const token = 'aaa.bbb.ccc';
+    localStorage.setItem('biltip_auth', JSON.stringify({ token }));
+
+    await apiClient('/test');
+
+    expect(fetch).toHaveBeenCalledWith(
+      'http://example.com/test',
+      expect.objectContaining({
+        headers: expect.objectContaining({ Authorization: `Bearer ${token}` }),
+      }),
+    );
+  });
+});

--- a/utils/apiClient.ts
+++ b/utils/apiClient.ts
@@ -29,11 +29,26 @@ export async function apiClient(
   const headers: Record<string, string> = {
     ...(init.headers as Record<string, string> | undefined),
   };
-  const tokenIsValid = typeof token === 'string' && token.length > 0 && token.split('.').length === 3;
+  // token is expected to be a JWT (three base64url segments)
+  const tokenIsValid = typeof token === 'string'
+    && /^[A-Za-z0-9-_]+\.[A-Za-z0-9-_]+\.[A-Za-z0-9-_]+$/.test(token);
+
+  if (process.env.NODE_ENV === 'development') {
+    console.debug('apiClient token:', token, 'valid JWT:', tokenIsValid);
+  }
+
   if (tokenIsValid) {
     headers['Authorization'] = `Bearer ${token}`;
-  } else if (process.env.NODE_ENV === 'development' && token) {
-    console.warn('Invalid auth token, Authorization header omitted');
+    if (process.env.NODE_ENV === 'development') {
+      console.debug('apiClient Authorization header appended');
+    }
+  } else {
+    if (process.env.NODE_ENV === 'development') {
+      console.debug('apiClient Authorization header omitted');
+    }
+    if (token) {
+      console.warn('Invalid auth token, Authorization header omitted');
+    }
   }
 
   const resource = typeof input === 'string'


### PR DESCRIPTION
## Summary
- tighten JWT validation in `apiClient`
- add development logs for token and header behavior
- add test to confirm Authorization header is sent when token is valid

## Testing
- `npm test` *(fails: Prisma client did not initialize, other suites failing)*
- `NODE_ENV=development npx vitest run utils/apiClient.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_68ac657867748323973a031bc925d49d