### PR TITLE
Add auth debugging logs

### DIFF
--- a/server/middleware/auth.js
+++ b/server/middleware/auth.js
@@ -15,15 +15,14 @@ export default async function authenticate(req, res, next) {
   }
 
   const authHeader = req.headers.authorization
+  console.debug(
+    'Authorization header:',
+    authHeader ? authHeader.replace(/^Bearer\s+.*/, 'Bearer [REDACTED]') : undefined
+  )
 
   if (!authHeader) {
     return res.status(401).json({ error: 'No token provided' })
   }
-
-  console.debug(
-    'Authorization header:',
-    authHeader.replace(/^Bearer\s+.*/, 'Bearer [REDACTED]')
-  )
 
   const parts = authHeader.split(' ')
   if (parts.length !== 2 || parts[0] !== 'Bearer') {

--- a/utils/apiClient.ts
+++ b/utils/apiClient.ts
@@ -44,7 +44,11 @@ export async function apiClient(
     }
   } else {
     if (process.env.NODE_ENV === 'development') {
-      console.debug('apiClient Authorization header omitted');
+      console.debug(
+        'apiClient Authorization header omitted',
+        'storedAuth:', storedAuth,
+        'tokenIsValid:', tokenIsValid,
+      );
     }
     if (token) {
       console.warn('Invalid auth token, Authorization header omitted');


### PR DESCRIPTION
## Summary
- log storedAuth and JWT validity when Authorization header is skipped
- log incoming Authorization header (redacted) before server validation

## Testing
- `npx vitest run repro.test.ts` (custom reproduction; token missing logs)
- `npm test` *(fails: Prisma client not initialized, multiple route tests failing)*

------
https://chatgpt.com/codex/tasks/task_e_68ac6995dc4483239f9a3e6105209d36