### PR TITLE
Allow mock tokens in api client

### DIFF
--- a/utils/apiClient.ts
+++ b/utils/apiClient.ts
@@ -30,8 +30,9 @@ export async function apiClient(
     ...(init.headers as Record<string, string> | undefined),
   };
   // token is expected to be a JWT (three base64url segments)
+  // When using the mock API, accept any token to allow development flows
   const tokenIsValid = typeof token === 'string'
-    && /^[A-Za-z0-9-_]+\.[A-Za-z0-9-_]+\.[A-Za-z0-9-_]+$/.test(token);
+    && (useMockApi || /^[A-Za-z0-9-_]+\.[A-Za-z0-9-_]+\.[A-Za-z0-9-_]+$/.test(token));
 
   if (process.env.NODE_ENV === 'development') {
     console.debug('apiClient token:', token, 'valid JWT:', tokenIsValid);


### PR DESCRIPTION
## Summary
- accept any token when using mock API so Authorization header is set
- add unit tests covering mock token and mock profile data

## Testing
- `npm test` *(fails: Cannot read properties of undefined - prisma environment)*
- `npx vitest run utils/apiClient.test.ts`
- `VITE_USE_MOCK_API=true npx vitest run utils/apiClient.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68ac6e8f6d6c83239f5d8cefbf45a707