### PR TITLE
feat: update CORS default port

### DIFF
--- a/server/.env.example
+++ b/server/.env.example
@@ -7,3 +7,6 @@ JWT_SECRET=your_jwt_secret_here
 # Log Authorization headers during authentication middleware
 # Set to "true" only for debugging. Leave unset or "false" in production.
 LOG_AUTH_HEADERS=false
+
+# URL of the frontend application (used for CORS)
+FRONTEND_URL=http://localhost:4000

--- a/server/server.js
+++ b/server/server.js
@@ -52,7 +52,7 @@ setInterval(() => cleanupExpiredCodes(prisma), 60 * 60 * 1000)
 // Middleware
 app.use(helmet())
 app.use(cors({
-  origin: process.env.FRONTEND_URL || 'http://localhost:3000',
+  origin: process.env.FRONTEND_URL || 'http://localhost:4000',
   credentials: true
 }))
 


### PR DESCRIPTION
## Summary
- default server CORS origin to `http://localhost:4000`
- document `FRONTEND_URL` in server env example

## Testing
- `npm test` *(fails: @prisma/client did not initialize yet, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68ac77b2ee4483239d4bba44651fa41d