### PR TITLE
Persist auth token after OTP verification

### DIFF
--- a/components/LoginScreen.tsx
+++ b/components/LoginScreen.tsx
@@ -122,7 +122,12 @@ export function LoginScreen({ onLogin, onShowRegister }: LoginScreenProps) {
           otp
         })
       });
-      saveAuth({ auth: { token: data.token }, user: data.user });
+      const authData = {
+        token: data.token,
+        expiresAt: Date.now() + 7 * 24 * 60 * 60 * 1000,
+        loginTime: new Date().toISOString(),
+      };
+      saveAuth({ auth: authData, user: data.user });
       onLogin({ token: data.token, user: data.user });
     } catch (error: any) {
       console.error('OTP verification error:', error);

--- a/utils/auth.ts
+++ b/utils/auth.ts
@@ -18,11 +18,13 @@ interface AuthStorageData {
 }
 
 export function saveAuth(data: AuthStorageData) {
+  if (typeof window === 'undefined') return;
   localStorage.setItem(AUTH_KEY, JSON.stringify(data.auth));
   localStorage.setItem(USER_KEY, JSON.stringify(data.user));
 }
 
 export function loadAuth(): AuthStorageData | null {
+  if (typeof window === 'undefined') return null;
   try {
     const authRaw = localStorage.getItem(AUTH_KEY);
     const userRaw = localStorage.getItem(USER_KEY);
@@ -37,6 +39,7 @@ export function loadAuth(): AuthStorageData | null {
 }
 
 export function clearAuth() {
+  if (typeof window === 'undefined') return;
   localStorage.removeItem(AUTH_KEY);
   localStorage.removeItem(USER_KEY);
 }


### PR DESCRIPTION
## Summary
- persist JWT and metadata after OTP verification
- guard auth storage helpers for non-browser environments

## Testing
- `npm test` *(fails: Error: @prisma/client did not initialize yet...)*

------
https://chatgpt.com/codex/tasks/task_e_68ac7f13742483238f80306ed9a5bc94