### PR TITLE
feat: add backoff for notification polling

### DIFF
--- a/components/ui/notification-bell.test.tsx
+++ b/components/ui/notification-bell.test.tsx
@@ -33,13 +33,15 @@ describe('NotificationBell', () => {
 
   it('displays error when fetch fails', async () => {
     vi.useRealTimers();
-    const fetchMock = vi.fn().mockResolvedValue({ ok: false });
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue({ ok: false, status: 500, json: async () => ({}) });
     global.fetch = fetchMock as any;
 
     render(<NotificationBell onClick={() => {}} />);
 
     expect(
-      await screen.findByText('Failed to fetch unread notifications', {}, { timeout: 10000 })
+      await screen.findByText(/Request failed with status 500/, {}, { timeout: 10000 })
     ).toBeInTheDocument();
     expect(
       await screen.findByRole('button', { name: /retry/i }, { timeout: 10000 })


### PR DESCRIPTION
## Summary
- add exponential backoff and SSE teardown for notification bell
- update notification bell tests for new error handling

## Testing
- `npm test` *(fails: 8 failed, 19 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68ac888dd11c832389b2f5f9b5d6163b