### PR TITLE
Return signed JWT from mock auth handler

### DIFF
--- a/mocks/auth.ts
+++ b/mocks/auth.ts
@@ -24,7 +24,14 @@ function sign(payload: Record<string, unknown>) {
 }
 
 export function generateMockToken(phone: string) {
-  return sign({ sub: 'demo-user', name: 'Demo User', phone });
+  const now = Math.floor(Date.now() / 1000);
+  return sign({
+    sub: 'demo-user',
+    name: 'Demo User',
+    phone,
+    iat: now,
+    exp: now + 7 * 24 * 60 * 60,
+  });
 }
 
 export async function handle(path: string, init?: RequestInit) {


### PR DESCRIPTION
## Summary
- include standard claims when signing mock auth tokens

## Testing
- `npm test` *(fails: Test Files 8 failed | 19 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68ac9c85a3088323b1f03ed49acca569