### PR TITLE
Clear stored auth on invalid token

### DIFF
--- a/utils/apiClient.test.ts
+++ b/utils/apiClient.test.ts
@@ -76,4 +76,23 @@ describe('apiClient', () => {
       },
     });
   });
+
+  it('clears stored auth and dispatches session-expired for invalid tokens', async () => {
+    const token = 'invalid';
+    localStorage.setItem('biltip_auth', JSON.stringify({ token }));
+    localStorage.setItem('biltip_user', JSON.stringify({ name: 'Tester' }));
+    const listener = vi.fn();
+    window.addEventListener('session-expired', listener);
+
+    await apiClient('/test');
+
+    expect(localStorage.getItem('biltip_auth')).toBeNull();
+    expect(localStorage.getItem('biltip_user')).toBeNull();
+    expect(listener).toHaveBeenCalledTimes(1);
+
+    const [, options] = (fetch as any).mock.calls[0];
+    expect(options.headers.Authorization).toBeUndefined();
+
+    window.removeEventListener('session-expired', listener);
+  });
 });

--- a/utils/apiClient.ts
+++ b/utils/apiClient.ts
@@ -6,6 +6,7 @@ import { handle as mockContacts } from '../mocks/contacts';
 import { handle as mockRequests } from '../mocks/requests';
 import { handle as mockAuth } from '../mocks/auth';
 import { handle as mockUsers } from '../mocks/users';
+import { clearAuth } from './auth';
 
 type MockHandler = (path: string, init?: RequestInit) => Promise<any>;
 
@@ -55,6 +56,10 @@ export async function apiClient(
     }
     if (token) {
       console.warn('Invalid auth token, Authorization header omitted');
+      clearAuth();
+      if (typeof window !== 'undefined') {
+        window.dispatchEvent(new CustomEvent('session-expired'));
+      }
     }
   }
 


### PR DESCRIPTION
## Summary
- clear stored `biltip_auth` and `biltip_user` when token validation fails
- dispatch a `session-expired` event to notify the user
- test removal of auth data and event dispatch for invalid tokens

## Testing
- `npx vitest run utils/apiClient.test.ts`
- `npm test` *(fails: @prisma/client did not initialize yet)*

------
https://chatgpt.com/codex/tasks/task_e_68ad7f849ed88323bebc2e455f5ae4c7