### PR TITLE
Handle onboarding redirects and placeholder screen

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -59,6 +59,7 @@ const VirtualAccountScreen = lazy(() => import('./components/VirtualAccountScree
 const BankingRedirectScreen = lazy(() => import('./components/BankingRedirectScreen').then(m => ({ default: m.BankingRedirectScreen })));
 const PaymentConfirmationScreen = lazy(() => import('./components/PaymentConfirmationScreen').then(m => ({ default: m.PaymentConfirmationScreen })));
 const SettlementScreen = lazy(() => import('./components/SettlementScreen').then(m => ({ default: m.SettlementScreen })));
+const OnboardingScreen = lazy(() => import('./components/OnboardingScreen').then(m => ({ default: m.OnboardingScreen })));
 
 // Navigation state management using useReducer
 interface NavigationState {
@@ -409,6 +410,17 @@ function AppContent() {
     }
   }, [navState.currentGroupId, handleNavigate]);
 
+  useEffect(() => {
+    const redirectListener = (e: Event) => {
+      const detail = (e as CustomEvent<string>).detail;
+      if (detail) {
+        handleNavigate('onboarding');
+      }
+    };
+    window.addEventListener('onboarding-required', redirectListener);
+    return () => window.removeEventListener('onboarding-required', redirectListener);
+  }, [handleNavigate]);
+
   const handleLogin = useCallback((authResponse?: any) => {
     try {
       setIsInitializing(true);
@@ -558,6 +570,8 @@ function AppContent() {
           return <SettingsScreen onNavigate={handleNavigate} />;
         case 'notifications':
           return <NotificationsScreen onNavigate={handleNavigate} />;
+        case 'onboarding':
+          return <OnboardingScreen onNavigate={handleNavigate} />;
         case 'account-settings':
           return <AccountSettingsScreen onNavigate={handleNavigate} />;
         case 'payment-methods':

--- a/components/OnboardingScreen.tsx
+++ b/components/OnboardingScreen.tsx
@@ -1,0 +1,15 @@
+import { Button } from './ui/button';
+
+interface OnboardingScreenProps {
+  onNavigate: (tab: string) => void;
+}
+
+export function OnboardingScreen({ onNavigate }: OnboardingScreenProps) {
+  return (
+    <div className="p-4 space-y-4">
+      <h1 className="text-xl font-semibold">Onboarding</h1>
+      <p>Onboarding flow coming soon.</p>
+      <Button onClick={() => onNavigate('home')}>Go to Home</Button>
+    </div>
+  );
+}

--- a/components/UserProfileContext.tsx
+++ b/components/UserProfileContext.tsx
@@ -1,5 +1,5 @@
 import { createContext, useContext, useState, ReactNode, useEffect } from 'react';
-import { apiClient } from '../utils/apiClient';
+import { apiClient, ApiRedirectError } from '../utils/apiClient';
 
 interface LinkedBankAccount {
   id: string;
@@ -184,7 +184,11 @@ export function UserProfileProvider({ children }: { children: ReactNode }) {
         }
       }
     } catch (error) {
-      console.error('Error fetching user profile:', error);
+      if (error instanceof ApiRedirectError) {
+        window.dispatchEvent(new CustomEvent('onboarding-required', { detail: error.redirect }));
+      } else {
+        console.error('Error fetching user profile:', error);
+      }
     }
   };
 
@@ -235,7 +239,11 @@ export function UserProfileProvider({ children }: { children: ReactNode }) {
         body: JSON.stringify(payload),
       });
     } catch (error) {
-      console.error('Error updating user profile:', error);
+      if (error instanceof ApiRedirectError) {
+        window.dispatchEvent(new CustomEvent('onboarding-required', { detail: error.redirect }));
+      } else {
+        console.error('Error updating user profile:', error);
+      }
     }
   };
 
@@ -268,7 +276,11 @@ export function UserProfileProvider({ children }: { children: ReactNode }) {
           }),
         });
       } catch (error) {
-        console.warn('Error updating app settings:', error);
+        if (error instanceof ApiRedirectError) {
+          window.dispatchEvent(new CustomEvent('onboarding-required', { detail: error.redirect }));
+        } else {
+          console.warn('Error updating app settings:', error);
+        }
       }
     })();
   };
@@ -287,7 +299,11 @@ export function UserProfileProvider({ children }: { children: ReactNode }) {
       });
       return data.settings as UserSettings;
     } catch (error) {
-      console.error('Error saving settings:', error);
+      if (error instanceof ApiRedirectError) {
+        window.dispatchEvent(new CustomEvent('onboarding-required', { detail: error.redirect }));
+      } else {
+        console.error('Error saving settings:', error);
+      }
     }
   };
 

--- a/utils/apiClient.test.ts
+++ b/utils/apiClient.test.ts
@@ -8,7 +8,7 @@ vi.mock('./config', () => ({
   },
 }));
 
-import { apiClient } from './apiClient';
+import { apiClient, ApiRedirectError } from './apiClient';
 
 describe('apiClient', () => {
   beforeEach(() => {
@@ -94,5 +94,15 @@ describe('apiClient', () => {
     expect(options.headers.Authorization).toBeUndefined();
 
     window.removeEventListener('session-expired', listener);
+  });
+
+  it('throws ApiRedirectError on 307 redirect', async () => {
+    (fetch as any).mockResolvedValueOnce({
+      status: 307,
+      ok: false,
+      json: () => Promise.resolve({ redirect: '/onboarding' }),
+    });
+
+    await expect(apiClient('/test')).rejects.toBeInstanceOf(ApiRedirectError);
   });
 });


### PR DESCRIPTION
## Summary
- detect 307 responses in api client and raise `ApiRedirectError`
- redirect to onboarding when backend requests it
- add simple Onboarding screen placeholder

## Testing
- `npm test` *(fails: @prisma/client did not initialize yet)*

------
https://chatgpt.com/codex/tasks/task_e_68ad8350952c8323839f4a8ebefaae9a