### PR TITLE
Fetch friends summary and display quick stats

### DIFF
--- a/components/FriendsList.test.tsx
+++ b/components/FriendsList.test.tsx
@@ -14,7 +14,8 @@ describe('FriendsList error handling', () => {
       .mockRejectedValueOnce(new Error('network error'))
       .mockRejectedValueOnce(new Error('network error'))
       .mockResolvedValueOnce({ friends: [{ id: '1', name: 'Alice', username: 'alice', status: 'active' }] })
-      .mockResolvedValueOnce({ outgoing: [] });
+      .mockResolvedValueOnce({ outgoing: [] })
+      .mockResolvedValueOnce({ owedToUser: 48.25, userOwes: 15 });
 
     render(<FriendsList onNavigate={() => {}} />);
 
@@ -22,9 +23,11 @@ describe('FriendsList error handling', () => {
 
     fireEvent.click(screen.getByRole('button', { name: /retry/i }));
 
-    await waitFor(() => expect(apiMock).toHaveBeenCalledTimes(4));
+    await waitFor(() => expect(apiMock).toHaveBeenCalledTimes(5));
     expect(screen.queryByRole('heading', { name: /failed to load friends/i })).not.toBeInTheDocument();
     expect(await screen.findByText('Alice')).toBeInTheDocument();
+    expect(screen.getByText('$48.25')).toBeInTheDocument();
+    expect(screen.getByText('$15.00')).toBeInTheDocument();
   });
 });
 


### PR DESCRIPTION
## Summary
- retrieve friends balance summary from `/api/friends/summary`
- surface owed and owing totals in FriendsList quick stats with fallback message
- adjust FriendsList tests for new summary call and values

## Testing
- `npm test` *(fails: @prisma/client did not initialize yet. Please run "prisma generate" and try to import it again.)*
- `npm run lint` *(fails: 281 problems (78 errors, 203 warnings))*

------
https://chatgpt.com/codex/tasks/task_e_68b626c2cb048323bce913b3e2a4c6a1