### PR TITLE
Filter active friends in useFriends

### DIFF
--- a/components/SendMoney.tsx
+++ b/components/SendMoney.tsx
@@ -100,7 +100,8 @@ export function SendMoney({ onNavigate, prefillData }: SendMoneyProps) {
           const tempFriend: Friend = {
             id: prefillData.recipientId,
             name: prefillData.recipientName,
-            phoneNumber: 'Not available'
+            phoneNumber: 'Not available',
+            status: 'active'
           };
           setSelectedFriend(tempFriend);
           setSelectedPaymentMethod(null);

--- a/components/SplitBill.tsx
+++ b/components/SplitBill.tsx
@@ -83,7 +83,8 @@ export function SplitBill({ onNavigate, groupId }: SplitBillProps) {
     id: 'me',
     name: 'You',
     avatar: 'https://images.unsplash.com/photo-1535713875002-d1d0cf377fde?w=150',
-    phoneNumber: isNigeria ? '+234 800 000 0000' : '+1 (555) 000-0000'
+    phoneNumber: isNigeria ? '+234 800 000 0000' : '+1 (555) 000-0000',
+    status: 'active'
   };
 
 

--- a/hooks/useFriends.ts
+++ b/hooks/useFriends.ts
@@ -6,6 +6,7 @@ export interface Friend {
   name: string;
   avatar?: string;
   phoneNumber?: string;
+  status: 'active' | 'pending' | 'blocked';
 }
 
 let friendsCache: Friend[] | null = null;
@@ -16,7 +17,9 @@ export async function fetchFriends(): Promise<Friend[]> {
   if (inflight) return inflight;
   inflight = apiClient('/friends')
     .then((data) => {
-      friendsCache = Array.isArray(data.friends) ? data.friends : [];
+      friendsCache = Array.isArray(data.friends)
+        ? data.friends.filter((f: Friend) => f.status === 'active')
+        : [];
       return friendsCache;
     })
     .finally(() => {

--- a/mocks/friends.ts
+++ b/mocks/friends.ts
@@ -1,9 +1,9 @@
 import type { Friend } from '../hooks/useFriends';
 
 const friends: Friend[] = [
-  { id: '1', name: 'Alice' },
-  { id: '2', name: 'Bob' },
-  { id: '3', name: 'Charlie' }
+  { id: '1', name: 'Alice', status: 'active' },
+  { id: '2', name: 'Bob', status: 'active' },
+  { id: '3', name: 'Charlie', status: 'active' }
 ];
 
 export async function handle(_path: string, _init?: RequestInit) {


### PR DESCRIPTION
## Summary
- only expose active friends from `useFriends`
- type friend status and update mock/temp data accordingly

## Testing
- `npm run lint` *(fails: 281 problems)*
- `npm test` *(fails: 14 failed, 13 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68b6281ec3e8832395b707143aa3b37d