### PR TITLE
Use summary from useTransactions in HomeScreen

### DIFF
--- a/components/HomeScreen.tsx
+++ b/components/HomeScreen.tsx
@@ -42,15 +42,7 @@ export function HomeScreen({ onNavigate }: HomeScreenProps) {
     loading: transactionsLoading,
     error: transactionsError,
   } = useTransactions();
-
-  // Calculate total amounts owed and owing from transactions
-  const totalOwed = transactions
-    .filter(t => t.type === 'received' && t.status === 'pending')
-    .reduce((sum, t) => sum + t.amount, 0);
-
-  const totalOwes = transactions
-    .filter(t => (t.type === 'split' || t.type === 'sent') && t.status === 'pending')
-    .reduce((sum, t) => sum + t.amount, 0);
+  const { summary } = useTransactions({ status: 'pending', limit: 0 });
 
   const filteredTransactions = transactions.filter(transaction => {
     if (activityFilter === 'all') return true;
@@ -90,19 +82,19 @@ export function HomeScreen({ onNavigate }: HomeScreenProps) {
       {/* Content Container */}
       <div className="px-4 space-y-6">
         {/* Balance Card */}
-        {(totalOwed > 0 || totalOwes > 0) && (
+        {(summary.totalReceived > 0 || summary.totalSent > 0) && (
           <Card className="p-4">
             <h3 className="font-medium mb-3">Your Balance</h3>
             <div className="grid grid-cols-2 gap-4">
               <div className="text-center">
                 <p className="text-2xl font-medium text-success">
-                  {currencySymbol}{totalOwed.toFixed(2)}
+                  {currencySymbol}{summary.totalReceived.toFixed(2)}
                 </p>
                 <p className="text-sm text-muted-foreground">You are owed</p>
               </div>
               <div className="text-center">
                 <p className="text-2xl font-medium text-destructive">
-                  {currencySymbol}{totalOwes.toFixed(2)}
+                  {currencySymbol}{summary.totalSent.toFixed(2)}
                 </p>
                 <p className="text-sm text-muted-foreground">You owe</p>
               </div>


### PR DESCRIPTION
## Summary
- remove manual owed/owe calculations and use `useTransactions` summary data
- display `summary.totalReceived` and `summary.totalSent` in balance card
- fetch pending-transaction summary via `useTransactions({ status: 'pending' })`

## Testing
- `npm test` *(fails: @prisma/client did not initialize yet)*

------
https://chatgpt.com/codex/tasks/task_e_68b64199b7888323bed76001c808df7b