### PR TITLE
Show participant avatars with graceful fallbacks

### DIFF
--- a/components/HomeScreen.tsx
+++ b/components/HomeScreen.tsx
@@ -3,7 +3,7 @@ import { Card } from './ui/card';
 import { Button } from './ui/button';
 import { TransactionCard } from './TransactionCard';
 import { UpcomingPayments } from './UpcomingPayments';
-import { Avatar, AvatarFallback } from './ui/avatar';
+import { Avatar, AvatarFallback, AvatarImage } from './ui/avatar';
 import { EmptyState } from './ui/empty-state';
 import { Send, Users, Receipt, Plus, DollarSign } from 'lucide-react';
 import { Alert, AlertDescription } from './ui/alert';
@@ -68,6 +68,7 @@ export function HomeScreen({ onNavigate }: HomeScreenProps) {
         <div className="flex items-center justify-between max-w-md mx-auto">
             <div className="flex items-center space-x-3">
               <Avatar className="h-10 w-10">
+                <AvatarImage src={userProfile?.avatar} />
                 <AvatarFallback className="bg-primary text-primary-foreground">
                   {initials}
                 </AvatarFallback>

--- a/components/TransactionCard.tsx
+++ b/components/TransactionCard.tsx
@@ -1,6 +1,6 @@
 import { ArrowUpRight, ArrowDownLeft, Users, Clock } from "lucide-react";
 import { Card } from "./ui/card";
-import { Avatar, AvatarFallback } from "./ui/avatar";
+import { Avatar, AvatarFallback, AvatarImage } from "./ui/avatar";
 import { Badge } from "./ui/badge";
 import { formatDate } from "../utils/formatDate";
 import type { TransactionType, TransactionStatus } from "../shared/transactions";
@@ -121,15 +121,21 @@ export function TransactionCard({ transaction, onNavigate, onClick, currencySymb
     
     // Fallback
     return {
-      name: transaction.type === 'bill_split' ? 'Bill Split' : 'Unknown',
-      avatar: transaction.avatarFallback || 'UN'
+      name: transaction.type === 'bill_split' ? 'Bill Split' : 'Unknown'
     };
   };
 
+  const getInitials = (name: string) =>
+    name
+      .split(' ')
+      .filter(Boolean)
+      .map(n => n[0])
+      .join('')
+      .slice(0, 2)
+      .toUpperCase();
+
   const userInfo = getUserInfo();
-  const avatarFallback = transaction.avatarFallback || 
-                        userInfo.avatar || 
-                        userInfo.name.split(' ').map(n => n[0]).join('').toUpperCase();
+  const avatarFallback = transaction.avatarFallback || getInitials(userInfo.name);
 
 
   const handleClick = () => {
@@ -146,6 +152,7 @@ export function TransactionCard({ transaction, onNavigate, onClick, currencySymb
         <div className="flex items-center space-x-3 min-w-0 flex-1">
           <div className="relative flex-shrink-0">
             <Avatar className="h-12 w-12">
+              <AvatarImage src={userInfo.avatar} />
               <AvatarFallback className="bg-muted text-xs">
                 {avatarFallback}
               </AvatarFallback>

--- a/components/UpcomingPayments.tsx
+++ b/components/UpcomingPayments.tsx
@@ -1,7 +1,7 @@
 import { Card } from './ui/card';
 import { Button } from './ui/button';
 import { Badge } from './ui/badge';
-import { Avatar, AvatarFallback } from './ui/avatar';
+import { Avatar, AvatarFallback, AvatarImage } from './ui/avatar';
 import { Clock, AlertTriangle, Calendar, Users, CreditCard, AlertCircle } from 'lucide-react';
 import { useUserProfile } from './UserProfileContext';
 import { ListSkeleton } from './ui/loading';
@@ -16,6 +16,14 @@ export function UpcomingPayments({ onNavigate }: UpcomingPaymentsProps) {
   const { appSettings } = useUserProfile();
   const currencySymbol = appSettings.region === 'NG' ? '₦' : '$';
   const { upcomingPayments, loading, error } = useUpcomingPayments();
+  const getInitials = (name: string) =>
+    name
+      .split(' ')
+      .filter(Boolean)
+      .map(n => n[0])
+      .join('')
+      .slice(0, 2)
+      .toUpperCase();
 
   const getStatusIcon = (status: string) => {
     switch (status) {
@@ -96,8 +104,9 @@ export function UpcomingPayments({ onNavigate }: UpcomingPaymentsProps) {
             <div className="flex items-center justify-between">
               <div className="flex items-center space-x-3">
                 <Avatar className="h-10 w-10">
+                  <AvatarImage src={payment.organizer.avatar} />
                   <AvatarFallback className="bg-primary text-primary-foreground">
-                    {payment.organizer.avatar}
+                    {getInitials(payment.organizer.name)}
                   </AvatarFallback>
                 </Avatar>
                 <div className="flex-1 min-w-0">


### PR DESCRIPTION
## Summary
- display user profile photo on home screen when available
- render participant avatars on transaction cards with initials fallback
- show organizer avatars on upcoming payments using AvatarImage

## Testing
- `node node_modules/vitest/vitest.mjs run`

------
https://chatgpt.com/codex/tasks/task_e_68b64ae8b630832394bc27abe286892c