### PR TITLE
refactor: remove api prefix from split bill creation

### DIFF
--- a/components/SplitBill.tsx
+++ b/components/SplitBill.tsx
@@ -477,7 +477,7 @@ export function SplitBill({ onNavigate, groupId }: SplitBillProps) {
           })),
       };
 
-      await apiClient('/api/bill-splits', {
+      await apiClient('/bill-splits', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(payload),


### PR DESCRIPTION
## Summary
- post split bills without `/api` prefix
- verify other split bill helpers already use relative paths

## Testing
- `npm test` *(fails: Prisma client did not initialize, missing test DB setup)*
- `npm run lint` *(fails: 302 problems (88 errors, 214 warnings))*

------
https://chatgpt.com/codex/tasks/task_e_68b6c6ea3c90832394a0d2e3a9d33643