### PR TITLE
Remove API prefix from bill split endpoints

### DIFF
--- a/components/BillPaymentScreen.tsx
+++ b/components/BillPaymentScreen.tsx
@@ -57,7 +57,7 @@ export function BillPaymentScreen({ billId, onNavigate }: BillPaymentScreenProps
     if (!billId) return;
     const loadBill = async () => {
       try {
-        const data = await apiClient(`/api/bill-splits/${billId}`);
+        const data = await apiClient(`/bill-splits/${billId}`);
         if (data?.billSplit) {
           setBill(data.billSplit);
         }
@@ -128,7 +128,7 @@ export function BillPaymentScreen({ billId, onNavigate }: BillPaymentScreenProps
   const markAsSent = async () => {
     if (!bill) return;
     try {
-      await apiClient(`/api/bill-splits/${bill.id}/payments`, {
+      await apiClient(`/bill-splits/${bill.id}/payments`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ status: 'SENT' })

--- a/components/BillSplitDetailsScreen.tsx
+++ b/components/BillSplitDetailsScreen.tsx
@@ -64,12 +64,12 @@ interface BillSplit {
 const billSplitCache = new Map<string, BillSplit>();
 
 async function getBillSplit(id: string): Promise<BillSplit> {
-  const data = await apiClient(`/api/bill-splits/${id}`);
+  const data = await apiClient(`/bill-splits/${id}`);
   return data.billSplit ?? data;
 }
 
 async function deleteBillSplit(id: string): Promise<void> {
-  await apiClient(`/api/bill-splits/${id}`, {
+  await apiClient(`/bill-splits/${id}`, {
     method: 'DELETE',
   });
 }

--- a/components/EditBillSplitScreen.tsx
+++ b/components/EditBillSplitScreen.tsx
@@ -65,17 +65,17 @@ interface BillSplit {
 }
 
 async function fetchBillSplit(id: string): Promise<BillSplit> {
-  const data = await apiClient(`/api/bill-splits/${id}`);
+  const data = await apiClient(`/bill-splits/${id}`);
   return data.billSplit ?? data;
 }
 
 async function fetchPaymentMethods(): Promise<PaymentMethod[]> {
-  const data = await apiClient('/api/payment-methods');
+  const data = await apiClient('/payment-methods');
   return data.paymentMethods ?? data;
 }
 
 async function updateBillSplit(id: string, payload: any): Promise<void> {
-  await apiClient(`/api/bill-splits/${id}`, {
+  await apiClient(`/bill-splits/${id}`, {
     method: 'PUT',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(payload)

--- a/components/SettlementScreen.tsx
+++ b/components/SettlementScreen.tsx
@@ -41,7 +41,7 @@ interface BillSplit {
 }
 
 async function getBillSplit(id: string): Promise<BillSplit> {
-  const data = await apiClient(`/api/bill-splits/${id}`);
+  const data = await apiClient(`/bill-splits/${id}`);
   return data.billSplit ?? data;
 }
 
@@ -53,7 +53,7 @@ async function initiateTransfer(payload: {
   amount: number;
   narration?: string;
 }): Promise<void> {
-  await apiClient('/api/initiate-transfer', {
+  await apiClient('/initiate-transfer', {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(payload)

--- a/components/SplitBill.tsx
+++ b/components/SplitBill.tsx
@@ -477,7 +477,7 @@ export function SplitBill({ onNavigate, groupId }: SplitBillProps) {
           })),
       };
 
-      await apiClient('/api/bill-splits', {
+      await apiClient('/bill-splits', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(payload),

--- a/hooks/useBillSplits.ts
+++ b/hooks/useBillSplits.ts
@@ -87,7 +87,7 @@ export function useBillSplits(initialOptions: UseBillSplitsOptions = {}): UseBil
         if (current.page) params.append('page', String(current.page));
         if (current.size) params.append('size', String(current.size));
 
-        const endpoint = `/api/bill-splits?${params.toString()}`;
+        const endpoint = `/bill-splits?${params.toString()}`;
         const data = await apiClient(endpoint);
         setBillSplits(Array.isArray(data.billSplits) ? data.billSplits : []);
         setTotal(data.total ?? 0);


### PR DESCRIPTION
## Summary
- point SplitBill creation to `/bill-splits` instead of `/api/bill-splits`
- align bill split related screens and hooks with new endpoint base

## Testing
- `npm test` *(fails: @prisma/client did not initialize yet, etc.)*
- `npm run lint` *(fails: 88 errors, 214 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68b6c7195f5483238d56e7af2efd8c37