### PR TITLE
feat: add friend search endpoint

### DIFF
--- a/mocks/friends.ts
+++ b/mocks/friends.ts
@@ -6,6 +6,17 @@ const friends: Friend[] = [
   { id: '3', name: 'Charlie', status: 'active' }
 ];
 
-export async function handle(_path: string, _init?: RequestInit) {
-  return { friends };
+export async function handle(path: string, _init?: RequestInit) {
+  if (path.startsWith('/friends/search')) {
+    const url = new URL(path, 'http://example.com');
+    const q = url.searchParams.get('q')?.toLowerCase() ?? '';
+    const results = friends.filter(f => f.name.toLowerCase().includes(q));
+    return { friends: results };
+  }
+
+  if (path === '/friends') {
+    return { friends };
+  }
+
+  return null;
 }


### PR DESCRIPTION
## Summary
- add `/friends/search` endpoint to query friends by name, email, or phone
- cover search behavior and empty queries in tests
- mock friends search for `useMockApi`

## Testing
- `npm test server/routes/friends.test.js`

------
https://chatgpt.com/codex/tasks/task_e_68b9556e613c832390b44f9b9bf0503f