### PR TITLE
feat: make transaction search case-insensitive

### DIFF
--- a/server/routes/transactions.js
+++ b/server/routes/transactions.js
@@ -96,11 +96,11 @@ router.get('/', async (req, res) => {
     if (keyword) {
       const keywordFilter = {
         OR: [
-          { description: { contains: keyword } },
-          { billSplit: { title: { contains: keyword } } },
-          { billSplit: { description: { contains: keyword } } },
-          { sender: { name: { contains: keyword } } },
-          { receiver: { name: { contains: keyword } } }
+          { description: { contains: keyword, mode: 'insensitive' } },
+          { billSplit: { title: { contains: keyword, mode: 'insensitive' } } },
+          { billSplit: { description: { contains: keyword, mode: 'insensitive' } } },
+          { sender: { name: { contains: keyword, mode: 'insensitive' } } },
+          { receiver: { name: { contains: keyword, mode: 'insensitive' } } }
         ]
       }
       baseWhere.AND = Array.isArray(baseWhere.AND)
@@ -293,11 +293,11 @@ router.get('/summary', async (req, res) => {
     if (keyword) {
       const keywordFilter = {
         OR: [
-          { description: { contains: keyword } },
-          { billSplit: { title: { contains: keyword } } },
-          { billSplit: { description: { contains: keyword } } },
-          { sender: { name: { contains: keyword } } },
-          { receiver: { name: { contains: keyword } } }
+          { description: { contains: keyword, mode: 'insensitive' } },
+          { billSplit: { title: { contains: keyword, mode: 'insensitive' } } },
+          { billSplit: { description: { contains: keyword, mode: 'insensitive' } } },
+          { sender: { name: { contains: keyword, mode: 'insensitive' } } },
+          { receiver: { name: { contains: keyword, mode: 'insensitive' } } }
         ]
       }
       baseWhere.AND = Array.isArray(baseWhere.AND)


### PR DESCRIPTION
## Summary
- support case-insensitive matching for transaction keyword filtering

## Testing
- `npm test` *(fails: Error: @prisma/client did not initialize yet)*

------
https://chatgpt.com/codex/tasks/task_e_68b9599603808323bc8a650807b5f7b8