### PR TITLE
Expose creator metadata for group accounts

### DIFF
--- a/components/GroupAccountScreen.tsx
+++ b/components/GroupAccountScreen.tsx
@@ -75,7 +75,11 @@ export function GroupAccountScreen({ groupId, onNavigate }: GroupAccountScreenPr
     if (!groupId) return;
     try {
       const data = await apiClient(`/api/groups/${groupId}/accounts`);
-      setGroupAccounts(data.accounts || []);
+      const accounts = (data.accounts || []).map((a: any) => ({
+        ...a,
+        createdDate: a.createdDate || a.createdAt,
+      }));
+      setGroupAccounts(accounts);
     } catch (error) {
       toast.error('Failed to load group accounts');
     }

--- a/components/VirtualAccountScreen.tsx
+++ b/components/VirtualAccountScreen.tsx
@@ -111,7 +111,11 @@ export function VirtualAccountScreen({ groupId, onNavigate }: VirtualAccountScre
     if (!groupId) return;
     try {
       const data = await apiClient(`/api/groups/${groupId}/accounts`);
-      setExternalAccounts(data.accounts || []);
+      const accounts = (data.accounts || []).map((a: any) => ({
+        ...a,
+        createdDate: a.createdDate || a.createdAt,
+      }));
+      setExternalAccounts(accounts);
     } catch (error) {
       toast.error('Failed to load group accounts');
     }

--- a/mocks/groups.ts
+++ b/mocks/groups.ts
@@ -27,7 +27,7 @@ const accounts: ExternalAccount[] = [
     accountHolderName: 'Mock User',
     routingNumber: '021000021',
     isDefault: true,
-    createdBy: '1',
+    createdBy: 'Mock User',
     createdDate: new Date().toISOString()
   }
 ];

--- a/server/routes/groupAccounts.js
+++ b/server/routes/groupAccounts.js
@@ -64,6 +64,7 @@ const formatAccount = (account) => ({
   id: account.id,
   groupId: account.groupId,
   createdById: account.createdById,
+  createdBy: account.createdBy?.name,
   name: account.name,
   type: account.type === 'BANK' ? 'bank' : 'mobile_money',
   accountType: account.accountType,
@@ -75,14 +76,15 @@ const formatAccount = (account) => ({
   provider: account.provider,
   phoneNumber: account.phoneNumber,
   isDefault: account.isDefault,
-  createdAt: account.createdAt
+  createdDate: account.createdAt.toISOString()
 })
 
 // List all accounts for a specific group
 router.get('/', async (req, res) => {
   try {
     const accounts = await req.prisma.groupAccount.findMany({
-      where: { groupId: req.params.groupId }
+      where: { groupId: req.params.groupId },
+      include: { createdBy: { select: { name: true } } }
     })
     res.json({ accounts: accounts.map(formatAccount) })
   } catch (error) {
@@ -131,7 +133,8 @@ router.post('/', requireGroupAdmin, async (req, res) => {
           type === 'bank'
             ? `${req.body.accountName} - ${req.body.bank}`
             : `${req.body.phoneNumber} - ${req.body.provider}`
-      }
+      },
+      include: { createdBy: { select: { name: true } } }
     })
 
     res.status(201).json({ account: formatAccount(account) })
@@ -160,7 +163,8 @@ router.put('/:accountId', requireGroupAdmin, async (req, res) => {
 
     const updated = await req.prisma.groupAccount.update({
       where: { id: account.id },
-      data: { ...req.body }
+      data: { ...req.body },
+      include: { createdBy: { select: { name: true } } }
     })
 
     res.json({ account: formatAccount(updated) })

--- a/utils/split-bill-api.ts
+++ b/utils/split-bill-api.ts
@@ -60,7 +60,10 @@ export async function fetchExternalAccounts(
 
   const data = await apiClient(`/groups/${groupId}/accounts`);
   const accounts: ExternalAccount[] = Array.isArray(data.accounts)
-    ? data.accounts
+    ? data.accounts.map((a: any) => ({
+        ...a,
+        createdDate: a.createdDate || a.createdAt,
+      }))
     : data;
   externalAccountsCache.set(groupId, accounts);
   return accounts;


### PR DESCRIPTION
## Summary
- join group accounts with users to include creator name and creation date
- normalize account creation date parsing on frontend components and API utilities
- align mock group account data with new fields

## Testing
- `npm test` *(fails: Unknown argument `mode` and other Prisma errors)*

------
https://chatgpt.com/codex/tasks/task_e_68b9603ae1d083238c33d7839f68439f