### PR TITLE
refactor: centralize financial data

### DIFF
--- a/server/routes/groupAccounts.js
+++ b/server/routes/groupAccounts.js
@@ -5,6 +5,10 @@ import {
   validateBankAccountNumber,
   hasValidPhonePrefix
 } from '../utils/regions.js'
+import {
+  BANK_DIRECTORY_BY_REGION,
+  MOBILE_MONEY_PROVIDERS_BY_REGION
+} from '../../shared/financial-data.js'
 
 // Use mergeParams to access groupId from parent router
 const router = express.Router({ mergeParams: true })
@@ -30,39 +34,16 @@ const requireGroupAdmin = async (req, res, next) => {
   }
 }
 
-const NIGERIAN_BANKS = [
-  { code: '044', name: 'Access Bank' },
-  { code: '063', name: 'Access Bank (Diamond)' },
-  { code: '023', name: 'Citi Bank' },
-  { code: '050', name: 'Ecobank Nigeria' },
-  { code: '070', name: 'Fidelity Bank' },
-  { code: '011', name: 'First Bank of Nigeria' },
-  { code: '214', name: 'First City Monument Bank' },
-  { code: '058', name: 'GTBank' },
-  { code: '221', name: 'Stanbic IBTC Bank' },
-  { code: '033', name: 'United Bank for Africa' },
-  { code: '057', name: 'Zenith Bank' }
-]
-
-const US_BANKS = [
-  { code: '021000021', name: 'Chase Bank' },
-  { code: '026009593', name: 'Bank of America' },
-  { code: '121000248', name: 'Wells Fargo' }
-]
-
-const MOBILE_MONEY_PROVIDERS = [
-  { code: 'opay', name: 'Opay' },
-  { code: 'palmpay', name: 'PalmPay' },
-  { code: 'kuda', name: 'Kuda Bank' },
-  { code: 'moniepoint', name: 'Moniepoint' }
-]
-
 const isValidBank = (bank) => {
-  return [...NIGERIAN_BANKS, ...US_BANKS].some((b) => b.name === bank)
+  return Object.values(BANK_DIRECTORY_BY_REGION)
+    .flat()
+    .some((b) => b.name === bank)
 }
 
 const isValidProvider = (provider) => {
-  return MOBILE_MONEY_PROVIDERS.some((p) => p.name === provider)
+  return Object.values(MOBILE_MONEY_PROVIDERS_BY_REGION)
+    .flat()
+    .some((p) => p.name === provider)
 }
 
 const formatAccount = (account) => ({

--- a/shared/financial-data.js
+++ b/shared/financial-data.js
@@ -1,0 +1,61 @@
+export const BANK_DIRECTORY_BY_REGION = {
+  NG: [
+    { code: '044', name: 'Access Bank' },
+    { code: '063', name: 'Access Bank (Diamond)' },
+    { code: '023', name: 'Citi Bank' },
+    { code: '050', name: 'Ecobank Nigeria' },
+    { code: '070', name: 'Fidelity Bank' },
+    { code: '011', name: 'First Bank of Nigeria' },
+    { code: '214', name: 'First City Monument Bank' },
+    { code: '058', name: 'GTBank' },
+    { code: '030', name: 'Heritage Bank' },
+    { code: '301', name: 'Jaiz Bank' },
+    { code: '082', name: 'Keystone Bank' },
+    { code: '221', name: 'Stanbic IBTC Bank' },
+    { code: '068', name: 'Standard Chartered Bank' },
+    { code: '232', name: 'Sterling Bank' },
+    { code: '032', name: 'Union Bank of Nigeria' },
+    { code: '033', name: 'United Bank for Africa' },
+    { code: '215', name: 'Unity Bank' },
+    { code: '035', name: 'Wema Bank' },
+    { code: '057', name: 'Zenith Bank' },
+  ],
+  US: [
+    { code: '026009593', name: 'Bank of America' },
+    { code: '021000021', name: 'Chase Bank' },
+    { code: '021000089', name: 'Citibank' },
+    { code: '121000248', name: 'Wells Fargo' },
+    { code: '091000019', name: 'U.S. Bank' },
+    { code: '221000113', name: 'TD Bank' },
+    { code: '031101279', name: 'PNC Bank' },
+    { code: '031176110', name: 'Capital One' },
+    { code: '061000052', name: 'Bank of the West' },
+    { code: '122000661', name: 'Ally Bank' },
+    { code: '124003116', name: 'Discover Bank' },
+    { code: '031201360', name: 'Regions Bank' },
+    { code: '063100277', name: 'Fifth Third Bank' },
+    { code: '044000024', name: 'KeyBank' },
+    { code: '053100300', name: 'BB&T (Truist)' },
+  ],
+};
+
+export const BANKS_BY_REGION = Object.fromEntries(
+  Object.entries(BANK_DIRECTORY_BY_REGION).map(([region, banks]) => [
+    region,
+    banks.map((b) => b.name),
+  ]),
+);
+
+export const MOBILE_MONEY_PROVIDERS_BY_REGION = {
+  NG: [
+    { code: 'opay', name: 'Opay' },
+    { code: 'palmpay', name: 'PalmPay' },
+    { code: 'kuda', name: 'Kuda Bank' },
+    { code: 'moniepoint', name: 'Moniepoint' },
+    { code: 'carbon', name: 'Carbon' },
+    { code: 'fairmoney', name: 'FairMoney' },
+    { code: 'cowrywise', name: 'Cowrywise' },
+    { code: 'piggyvest', name: 'PiggyVest' },
+  ],
+  US: [],
+};

--- a/shared/financial-data.ts
+++ b/shared/financial-data.ts
@@ -1,0 +1,64 @@
+export type BankRecord = { code: string; name: string };
+export type ProviderRecord = { code: string; name: string };
+
+export const BANK_DIRECTORY_BY_REGION: Record<string, BankRecord[]> = {
+  NG: [
+    { code: '044', name: 'Access Bank' },
+    { code: '063', name: 'Access Bank (Diamond)' },
+    { code: '023', name: 'Citi Bank' },
+    { code: '050', name: 'Ecobank Nigeria' },
+    { code: '070', name: 'Fidelity Bank' },
+    { code: '011', name: 'First Bank of Nigeria' },
+    { code: '214', name: 'First City Monument Bank' },
+    { code: '058', name: 'GTBank' },
+    { code: '030', name: 'Heritage Bank' },
+    { code: '301', name: 'Jaiz Bank' },
+    { code: '082', name: 'Keystone Bank' },
+    { code: '221', name: 'Stanbic IBTC Bank' },
+    { code: '068', name: 'Standard Chartered Bank' },
+    { code: '232', name: 'Sterling Bank' },
+    { code: '032', name: 'Union Bank of Nigeria' },
+    { code: '033', name: 'United Bank for Africa' },
+    { code: '215', name: 'Unity Bank' },
+    { code: '035', name: 'Wema Bank' },
+    { code: '057', name: 'Zenith Bank' },
+  ],
+  US: [
+    { code: '026009593', name: 'Bank of America' },
+    { code: '021000021', name: 'Chase Bank' },
+    { code: '021000089', name: 'Citibank' },
+    { code: '121000248', name: 'Wells Fargo' },
+    { code: '091000019', name: 'U.S. Bank' },
+    { code: '221000113', name: 'TD Bank' },
+    { code: '031101279', name: 'PNC Bank' },
+    { code: '031176110', name: 'Capital One' },
+    { code: '061000052', name: 'Bank of the West' },
+    { code: '122000661', name: 'Ally Bank' },
+    { code: '124003116', name: 'Discover Bank' },
+    { code: '031201360', name: 'Regions Bank' },
+    { code: '063100277', name: 'Fifth Third Bank' },
+    { code: '044000024', name: 'KeyBank' },
+    { code: '053100300', name: 'BB&T (Truist)' },
+  ],
+};
+
+export const BANKS_BY_REGION: Record<string, string[]> = Object.fromEntries(
+  Object.entries(BANK_DIRECTORY_BY_REGION).map(([region, banks]) => [
+    region,
+    banks.map((b) => b.name),
+  ]),
+);
+
+export const MOBILE_MONEY_PROVIDERS_BY_REGION: Record<string, ProviderRecord[]> = {
+  NG: [
+    { code: 'opay', name: 'Opay' },
+    { code: 'palmpay', name: 'PalmPay' },
+    { code: 'kuda', name: 'Kuda Bank' },
+    { code: 'moniepoint', name: 'Moniepoint' },
+    { code: 'carbon', name: 'Carbon' },
+    { code: 'fairmoney', name: 'FairMoney' },
+    { code: 'cowrywise', name: 'Cowrywise' },
+    { code: 'piggyvest', name: 'PiggyVest' },
+  ],
+  US: [],
+};

--- a/utils/banks.ts
+++ b/utils/banks.ts
@@ -1,87 +1,18 @@
 import { getRegionConfig, RegionCode } from './regions';
-
-// Region-specific bank registries. Extend without touching UI components.
-const BANKS_BY_REGION: Record<string, string[]> = {
-  NG: [
-    'Access Bank',
-    'First Bank of Nigeria',
-    'First City Monument Bank (FCMB)',
-    'Guaranty Trust Bank (GTBank)',
-    'United Bank for Africa (UBA)',
-    'Zenith Bank',
-    'Polaris Bank',
-    'Union Bank',
-    'Fidelity Bank',
-    'Ecobank',
-    'Stanbic IBTC Bank',
-    'Sterling Bank',
-    'Keystone Bank',
-    'Unity Bank',
-    'Heritage Bank',
-    'Standard Chartered Bank',
-  ],
-  US: [
-    'Bank of America',
-    'Chase Bank',
-    'Citibank',
-    'Wells Fargo',
-    'U.S. Bank',
-    'PNC Bank',
-    'TD Bank',
-    'Capital One',
-  ],
-};
+import {
+  BANKS_BY_REGION,
+  BANK_DIRECTORY_BY_REGION,
+  type BankRecord,
+} from '../shared/financial-data';
 
 export function getBanksForRegion(region: RegionCode | undefined | null): string[] {
   const cfg = getRegionConfig(region);
   return BANKS_BY_REGION[cfg.code] ?? [];
 }
 
-// Optional: directory with bank codes per region for screens that need codes
-type BankRecord = { code: string; name: string };
-
-const BANK_DIRECTORY_BY_REGION: Record<string, BankRecord[]> = {
-  NG: [
-    { code: '044', name: 'Access Bank' },
-    { code: '063', name: 'Access Bank (Diamond)' },
-    { code: '023', name: 'Citi Bank' },
-    { code: '050', name: 'Ecobank Nigeria' },
-    { code: '070', name: 'Fidelity Bank' },
-    { code: '011', name: 'First Bank of Nigeria' },
-    { code: '214', name: 'First City Monument Bank' },
-    { code: '058', name: 'GTBank' },
-    { code: '030', name: 'Heritage Bank' },
-    { code: '301', name: 'Jaiz Bank' },
-    { code: '082', name: 'Keystone Bank' },
-    { code: '221', name: 'Stanbic IBTC Bank' },
-    { code: '068', name: 'Standard Chartered Bank' },
-    { code: '232', name: 'Sterling Bank' },
-    { code: '032', name: 'Union Bank of Nigeria' },
-    { code: '033', name: 'United Bank for Africa' },
-    { code: '215', name: 'Unity Bank' },
-    { code: '035', name: 'Wema Bank' },
-    { code: '057', name: 'Zenith Bank' },
-  ],
-  US: [
-    { code: '026009593', name: 'Bank of America' },
-    { code: '021000021', name: 'Chase Bank' },
-    { code: '021000089', name: 'Citibank' },
-    { code: '121000248', name: 'Wells Fargo' },
-    { code: '091000019', name: 'U.S. Bank' },
-    { code: '221000113', name: 'TD Bank' },
-    { code: '031101279', name: 'PNC Bank' },
-    { code: '031176110', name: 'Capital One' },
-    { code: '061000052', name: 'Bank of the West' },
-    { code: '122000661', name: 'Ally Bank' },
-    { code: '124003116', name: 'Discover Bank' },
-    { code: '031201360', name: 'Regions Bank' },
-    { code: '063100277', name: 'Fifth Third Bank' },
-    { code: '044000024', name: 'KeyBank' },
-    { code: '053100300', name: 'BB&T (Truist)' },
-  ],
-};
-
-export function getBankDirectoryForRegion(region: RegionCode | undefined | null): BankRecord[] {
+export function getBankDirectoryForRegion(
+  region: RegionCode | undefined | null,
+): BankRecord[] {
   const cfg = getRegionConfig(region);
   return BANK_DIRECTORY_BY_REGION[cfg.code] ?? [];
 }

--- a/utils/providers.ts
+++ b/utils/providers.ts
@@ -1,23 +1,13 @@
 import { getRegionConfig, RegionCode } from './regions';
+import {
+  MOBILE_MONEY_PROVIDERS_BY_REGION,
+  type ProviderRecord,
+} from '../shared/financial-data';
 
-export type ProviderRecord = { code: string; name: string };
-
-const PROVIDERS_BY_REGION: Record<string, ProviderRecord[]> = {
-  NG: [
-    { code: 'opay', name: 'Opay' },
-    { code: 'palmpay', name: 'PalmPay' },
-    { code: 'kuda', name: 'Kuda Bank' },
-    { code: 'moniepoint', name: 'Moniepoint' },
-    { code: 'carbon', name: 'Carbon' },
-    { code: 'fairmoney', name: 'FairMoney' },
-    { code: 'cowrywise', name: 'Cowrywise' },
-    { code: 'piggyvest', name: 'PiggyVest' },
-  ],
-  US: [],
-};
-
-export function getMobileMoneyProviders(region: RegionCode | undefined | null): ProviderRecord[] {
+export function getMobileMoneyProviders(
+  region: RegionCode | undefined | null,
+): ProviderRecord[] {
   const cfg = getRegionConfig(region);
-  return PROVIDERS_BY_REGION[cfg.code] ?? [];
+  return MOBILE_MONEY_PROVIDERS_BY_REGION[cfg.code] ?? [];
 }
 


### PR DESCRIPTION
## Summary
- add shared financial data module for banks and mobile money providers
- refactor bank and provider utilities to read from shared module
- update group account routes to validate against shared data

## Testing
- `npm test` *(fails: components/ui/notification-bell.test.tsx > NotificationBell > polls for unread notifications)*

------
https://chatgpt.com/codex/tasks/task_e_68b969032cc883239b7df1f2515ed6b0