### PR TITLE
feat(server): include member details in group creation

### DIFF
--- a/server/routes/groups.js
+++ b/server/routes/groups.js
@@ -213,7 +213,7 @@ router.post('/', authenticate, async (req, res) => {
       include: {
         members: {
           include: {
-            user: { select: { id: true, name: true, avatar: true } }
+            user: { select: { id: true, name: true, avatar: true, phone: true } }
           }
         }
       }
@@ -224,6 +224,14 @@ router.post('/', authenticate, async (req, res) => {
       fullGroup,
       req.user.id
     )
+    // Return full member objects so the client can immediately navigate
+    // to the group detail view with member information available.
+    formattedGroup.members = fullGroup.members.map((m) => ({
+      id: m.user.id,
+      name: m.user.name,
+      avatar: m.user.avatar || '',
+      phoneNumber: m.user.phone || ''
+    }))
 
     res.status(201).json({ group: formattedGroup })
   } catch (error) {

--- a/server/routes/groups.test.js
+++ b/server/routes/groups.test.js
@@ -137,11 +137,15 @@ describe('Group join/leave routes', () => {
       memberCount: 3
     })
     expect(res.body.group.members).toEqual(
-      expect.arrayContaining(['U1', 'U2', 'C'])
+      expect.arrayContaining([
+        expect.objectContaining({ id: 'u1', name: 'User 1' }),
+        expect.objectContaining({ id: 'u2', name: 'User 2' }),
+        expect.objectContaining({ id: 'creator', name: 'Creator' })
+      ])
     )
   })
 
-  it('returns member previews without ids', async () => {
+  it('returns member objects with ids', async () => {
     const res = await request(app)
       .post('/groups')
       .set('x-user-id', 'creator')
@@ -150,7 +154,8 @@ describe('Group join/leave routes', () => {
     expect(res.status).toBe(201)
     const members = res.body.group.members
     expect(Array.isArray(members)).toBe(true)
-    expect(typeof members[0]).toBe('string')
+    expect(members[0]).toHaveProperty('id')
+    expect(members[0]).toHaveProperty('name')
   })
 
   it('rejects empty memberIds array', async () => {


### PR DESCRIPTION
## Summary
- return full member objects when creating a group
- test group creation returns member objects

## Testing
- `ALLOW_HEADER_AUTH=true npx vitest run server/routes/groups.test.js`

------
https://chatgpt.com/codex/tasks/task_e_68b96d4093048323995f6bd9850efbc7