### PR TITLE
Add mock contacts matching with toggleable API mode

### DIFF
--- a/mocks/contacts.ts
+++ b/mocks/contacts.ts
@@ -1,0 +1,39 @@
+import type { MatchedContact } from '../components/contact-sync/types';
+
+const demoMatches: MatchedContact[] = [
+  {
+    id: '1',
+    name: 'Alice Johnson',
+    phone: '+1234567890',
+    email: 'alice@example.com',
+    status: 'existing_user',
+    userId: 'u1',
+    username: 'alice',
+    mutualFriends: 3,
+    avatar: 'https://example.com/avatar1.png'
+  },
+  {
+    id: '2',
+    name: 'Bob Smith',
+    phone: '+1234567891',
+    email: 'bob@example.com',
+    status: 'not_on_app'
+  },
+  {
+    id: '3',
+    name: 'Charlie Brown',
+    phone: '+1234567892',
+    email: 'charlie@example.com',
+    status: 'existing_user',
+    userId: 'u3',
+    username: 'charlie',
+    avatar: 'https://example.com/avatar3.png'
+  }
+];
+
+export async function handle(path: string, init: RequestInit = {}) {
+  if (path === '/contacts/match' && init.method === 'POST') {
+    return { contacts: demoMatches };
+  }
+  return null;
+}

--- a/utils/apiClient.ts
+++ b/utils/apiClient.ts
@@ -5,11 +5,13 @@ import { handle as mockUpcomingPayments } from '../mocks/upcoming-payments';
 import { handle as mockRequests } from '../mocks/requests';
 import { handle as mockAuth } from '../mocks/auth';
 import { handle as mockUsers } from '../mocks/users';
+import { handle as mockContacts } from '../mocks/contacts';
 import { clearAuth } from './auth';
 
 type MockHandler = (path: string, init?: RequestInit) => Promise<any>;
 
 const mockRoutes: Array<{ test: RegExp; handler: MockHandler }> = [
+  { test: /^\/contacts/, handler: mockContacts },
   { test: /^\/friends/, handler: mockFriends },
   { test: /^\/groups/, handler: mockGroups },
   { test: /^\/upcoming-payments/, handler: mockUpcomingPayments },


### PR DESCRIPTION
## Summary
- add mock handler for `/contacts/match`
- wire mock contacts into apiClient
- allow `matchContacts` to return mock data when `VITE_USE_MOCK_API` is enabled

## Testing
- `npm run lint` *(fails: ESLint couldn't find an eslint.config file)*
- `VITE_USE_MOCK_API=true npm test` *(fails: multiple test failures)*
- `VITE_USE_MOCK_API=false npm test` *(fails: Prisma validation errors)*

------
https://chatgpt.com/codex/tasks/task_e_68b979f97448832397cf1e751a7c0967