### PR TITLE
feat: add heartbeat and redis-backed notification stream

### DIFF
--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -20,6 +20,7 @@
         "jsonwebtoken": "^9.0.2",
         "multer": "^1.4.5-lts.1",
         "node-cron": "^4.2.1",
+        "redis": "^4.6.7",
         "twilio": "^4.23.0"
       },
       "devDependencies": {
@@ -178,6 +179,65 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@prisma/debug": "5.22.0"
+      }
+    },
+    "node_modules/@redis/bloom": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@redis/bloom/-/bloom-1.2.0.tgz",
+      "integrity": "sha512-HG2DFjYKbpNmVXsa0keLHp/3leGJz1mjh09f2RLGGLQZzSHpkmZWuwJbAvo3QcRY8p80m5+ZdXZdYOSBLlp7Cg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@redis/client": "^1.0.0"
+      }
+    },
+    "node_modules/@redis/client": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@redis/client/-/client-1.6.1.tgz",
+      "integrity": "sha512-/KCsg3xSlR+nCK8/8ZYSknYxvXHwubJrU82F3Lm1Fp6789VQ0/3RJKfsmRXjqfaTA++23CvC3hqmqe/2GEt6Kw==",
+      "license": "MIT",
+      "dependencies": {
+        "cluster-key-slot": "1.1.2",
+        "generic-pool": "3.9.0",
+        "yallist": "4.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@redis/graph": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@redis/graph/-/graph-1.1.1.tgz",
+      "integrity": "sha512-FEMTcTHZozZciLRl6GiiIB4zGm5z5F3F6a6FZCyrfxdKOhFlGkiAqlexWMBzCi4DcRoyiOsuLfW+cjlGWyExOw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@redis/client": "^1.0.0"
+      }
+    },
+    "node_modules/@redis/json": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/@redis/json/-/json-1.0.7.tgz",
+      "integrity": "sha512-6UyXfjVaTBTJtKNG4/9Z8PSpKE6XgSyEb8iwaqDcy+uKrd/DGYHTWkUdnQDyzm727V7p21WUMhsqz5oy65kPcQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@redis/client": "^1.0.0"
+      }
+    },
+    "node_modules/@redis/search": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@redis/search/-/search-1.2.0.tgz",
+      "integrity": "sha512-tYoDBbtqOVigEDMAcTGsRlMycIIjwMCgD8eR2t0NANeQmgK/lvxNAvYyb6bZDD4frHRhIHkJu2TBRvB0ERkOmw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@redis/client": "^1.0.0"
+      }
+    },
+    "node_modules/@redis/time-series": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@redis/time-series/-/time-series-1.1.0.tgz",
+      "integrity": "sha512-c1Q99M5ljsIuc4YdaCwfUEXsofakb9c8+Zse2qxTadu8TalLXuAESzLvFAvNVbkmSlvlzIQOLpBCmWI9wTOt+g==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@redis/client": "^1.0.0"
       }
     },
     "node_modules/@types/body-parser": {
@@ -1029,6 +1089,15 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/generic-pool": {
+      "version": "3.9.0",
+      "resolved": "https://registry.npmjs.org/generic-pool/-/generic-pool-3.9.0.tgz",
+      "integrity": "sha512-hymDOu5B53XvN4QT9dBmZxPX4CWhBPPLguTZ9MMFeFa/Kg0xWVfylOVNlJji/E7yTZWFd/q9GO5TxDLq156D7g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
       }
     },
     "node_modules/get-intrinsic": {
@@ -1914,6 +1983,23 @@
         "node": ">=8.10.0"
       }
     },
+    "node_modules/redis": {
+      "version": "4.7.1",
+      "resolved": "https://registry.npmjs.org/redis/-/redis-4.7.1.tgz",
+      "integrity": "sha512-S1bJDnqLftzHXHP8JsT5II/CtHWQrASX5K96REjWjlmWKrviSOLWmM7QnRLstAWsu1VBBV1ffV6DzCvxNP0UJQ==",
+      "license": "MIT",
+      "workspaces": [
+        "./packages/*"
+      ],
+      "dependencies": {
+        "@redis/bloom": "1.2.0",
+        "@redis/client": "1.6.1",
+        "@redis/graph": "1.1.1",
+        "@redis/json": "1.0.7",
+        "@redis/search": "1.2.0",
+        "@redis/time-series": "1.1.0"
+      }
+    },
     "node_modules/redis-errors": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/redis-errors/-/redis-errors-1.2.0.tgz",
@@ -2343,6 +2429,12 @@
       "engines": {
         "node": ">=0.4"
       }
+    },
+    "node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "license": "ISC"
     }
   }
 }

--- a/server/package.json
+++ b/server/package.json
@@ -26,7 +26,8 @@
     "multer": "^1.4.5-lts.1",
     "node-cron": "^4.2.1",
     "bull": "^4.11.5",
-    "twilio": "^4.23.0"
+    "twilio": "^4.23.0",
+    "redis": "^4.6.7"
   },
   "devDependencies": {
     "@types/multer": "^2.0.0",

--- a/server/utils/notificationStream.js
+++ b/server/utils/notificationStream.js
@@ -1,16 +1,98 @@
-const clients = new Map();
+import { createClient } from 'redis'
+
+// In-memory map of connected clients keyed by userId
+const clients = new Map()
+
+// Heartbeat interval and timeout thresholds (ms)
+const HEARTBEAT_INTERVAL = 30_000
+const CLIENT_TIMEOUT = 90_000
+
+// Redis pub/sub setup for horizontal scaling
+const CHANNEL = 'notifications'
+let pub
+let sub
+
+if (process.env.REDIS_URL) {
+  try {
+    pub = createClient({ url: process.env.REDIS_URL })
+    sub = createClient({ url: process.env.REDIS_URL })
+
+    pub.on('error', err => console.error('Redis pub error:', err))
+    sub.on('error', err => console.error('Redis sub error:', err))
+
+    pub.connect().catch(err => console.error('Redis pub connect error:', err))
+    sub
+      .connect()
+      .then(() =>
+        sub.subscribe(CHANNEL, message => {
+          try {
+            const { userId, data } = JSON.parse(message)
+            dispatch(userId, data)
+          } catch (err) {
+            console.error('Redis message error:', err)
+          }
+        })
+      )
+      .catch(err => console.error('Redis sub connect error:', err))
+  } catch (err) {
+    console.error('Redis init error:', err)
+  }
+}
+
+function resetTimeout(client) {
+  clearTimeout(client.timeout)
+  client.timeout = setTimeout(() => {
+    removeClient(client.userId)
+  }, CLIENT_TIMEOUT)
+}
+
+function dispatch(userId, data) {
+  const client = clients.get(userId)
+  if (!client) return
+  try {
+    client.res.write(`data: ${JSON.stringify(data)}\n\n`)
+    resetTimeout(client)
+  } catch (err) {
+    removeClient(userId)
+  }
+}
 
 export function addClient(userId, res) {
-  clients.set(userId, res);
+  const client = { userId, res }
+
+  res.on('close', () => removeClient(userId))
+  res.on('error', () => removeClient(userId))
+
+  client.heartbeat = setInterval(() => {
+    try {
+      res.write(`event: heartbeat\ndata: ${Date.now()}\n\n`)
+      resetTimeout(client)
+    } catch (err) {
+      removeClient(userId)
+    }
+  }, HEARTBEAT_INTERVAL)
+
+  resetTimeout(client)
+  clients.set(userId, client)
 }
 
 export function removeClient(userId) {
-  clients.delete(userId);
-}
-
-export function sendEvent(userId, data) {
-  const client = clients.get(userId);
+  const client = clients.get(userId)
   if (client) {
-    client.write(`data: ${JSON.stringify(data)}\n\n`);
+    clearInterval(client.heartbeat)
+    clearTimeout(client.timeout)
+    try {
+      client.res.end()
+    } catch {}
+    clients.delete(userId)
   }
 }
+
+export async function sendEvent(userId, data) {
+  if (pub && pub.isOpen) {
+    await pub.publish(CHANNEL, JSON.stringify({ userId, data }))
+  } else {
+    dispatch(userId, data)
+  }
+}
+


### PR DESCRIPTION
## Summary
- send periodic heartbeat events to keep SSE connections fresh and drop clients that miss timeouts
- remove clients on `error` events and message write failures
- publish notification events over Redis for horizontal scale

## Testing
- `npm test` *(fails: Prisma validation and migration errors)*

------
https://chatgpt.com/codex/tasks/task_e_68bee30ab15883238eba26d26b02e534