### PR TITLE
Add friendly due date formatting for upcoming payments

### DIFF
--- a/components/UpcomingPayments.tsx
+++ b/components/UpcomingPayments.tsx
@@ -5,6 +5,7 @@ import { Avatar, AvatarFallback, AvatarImage } from './ui/avatar';
 import { Clock, AlertTriangle, Calendar, Users, CreditCard, AlertCircle } from 'lucide-react';
 import { useUserProfile } from './UserProfileContext';
 import { formatCurrencyForRegion } from '../utils/regions';
+import { formatDueDate } from '../utils/formatDueDate';
 import { ListSkeleton } from './ui/loading';
 import { Alert, AlertDescription } from './ui/alert';
 import { useUpcomingPayments } from '../hooks/useUpcomingPayments';
@@ -92,78 +93,90 @@ export function UpcomingPayments({ onNavigate }: UpcomingPaymentsProps) {
       </div>
 
       <div className="space-y-3">
-        {upcomingPayments.slice(0, 2).map((payment) => (
-          <Card key={payment.id} className="p-4 hover:bg-muted/50 transition-colors cursor-pointer" 
-                onClick={() => {
-                  if (payment.type === 'bill_split' && payment.billSplitId) {
-                    onNavigate('bill-split-details', { billSplitId: payment.billSplitId });
-                  } else if (payment.type === 'request' && payment.requestId) {
-                    onNavigate('transaction-details', { transactionId: payment.requestId });
-                  }
-                }}>
-            <div className="flex items-center justify-between">
-              <div className="flex items-center space-x-3">
-                <Avatar className="h-10 w-10">
-                  <AvatarImage src={payment.organizer.avatar} />
-                  <AvatarFallback className="bg-primary text-primary-foreground">
-                    {getInitials(payment.organizer.name)}
-                  </AvatarFallback>
-                </Avatar>
-                <div className="flex-1 min-w-0">
-                  <div className="flex items-center space-x-2 mb-1">
-                    {getTypeIcon(payment.type)}
-                    <p className="font-medium truncate">{payment.title}</p>
-                  </div>
-                  <p className="text-sm text-muted-foreground">
-                    {payment.organizer.name} • {Array.isArray(payment.participants) ? payment.participants.length : payment.participants} people
-                  </p>
-                  
-                  {/* Show payment method info if available */}
-                  {payment.paymentMethod && (
-                    <p className="text-xs text-muted-foreground mt-1">
-                      {payment.paymentMethod.type === 'bank' ? (
-                        <>Pay via {payment.paymentMethod.bankName}</>
-                      ) : (
-                        <>Pay via {payment.paymentMethod.provider}</>
-                      )}
+        {upcomingPayments.slice(0, 2).map((payment) => {
+          const duePhrase = formatDueDate(payment.dueDate);
+          const dueText = duePhrase
+            ? duePhrase.toLowerCase().startsWith('overdue')
+              ? duePhrase
+              : `Due ${duePhrase}`
+            : 'Due date unavailable';
+
+          return (
+            <Card
+              key={payment.id}
+              className="p-4 hover:bg-muted/50 transition-colors cursor-pointer"
+              onClick={() => {
+                if (payment.type === 'bill_split' && payment.billSplitId) {
+                  onNavigate('bill-split-details', { billSplitId: payment.billSplitId });
+                } else if (payment.type === 'request' && payment.requestId) {
+                  onNavigate('transaction-details', { transactionId: payment.requestId });
+                }
+              }}
+            >
+              <div className="flex items-center justify-between">
+                <div className="flex items-center space-x-3">
+                  <Avatar className="h-10 w-10">
+                    <AvatarImage src={payment.organizer.avatar} />
+                    <AvatarFallback className="bg-primary text-primary-foreground">
+                      {getInitials(payment.organizer.name)}
+                    </AvatarFallback>
+                  </Avatar>
+                  <div className="flex-1 min-w-0">
+                    <div className="flex items-center space-x-2 mb-1">
+                      {getTypeIcon(payment.type)}
+                      <p className="font-medium truncate">{payment.title}</p>
+                    </div>
+                    <p className="text-sm text-muted-foreground">
+                      {payment.organizer.name} • {Array.isArray(payment.participants) ? payment.participants.length : payment.participants} people
                     </p>
-                  )}
+
+                    {/* Show payment method info if available */}
+                    {payment.paymentMethod && (
+                      <p className="text-xs text-muted-foreground mt-1">
+                        {payment.paymentMethod.type === 'bank' ? (
+                          <>Pay via {payment.paymentMethod.bankName}</>
+                        ) : (
+                          <>Pay via {payment.paymentMethod.provider}</>
+                        )}
+                      </p>
+                    )}
+                  </div>
+                </div>
+                <div className="text-right space-y-2">
+                  <p className="font-medium">{formatCurrencyForRegion(appSettings.region, payment.amount)}</p>
+                  <Badge className={`${getStatusColor(payment.status)} text-xs flex items-center gap-1`}>
+                    {getStatusIcon(payment.status)}
+                    {dueText}
+                  </Badge>
+                  <Button
+                    size="sm"
+                    variant={payment.status === 'overdue' || payment.status === 'due_soon' ? 'default' : 'outline'}
+                    className="w-full"
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      if (payment.type === 'bill_split' && payment.billSplitId) {
+                        onNavigate('pay-bill', { billId: payment.billSplitId });
+                      } else {
+                        // For direct money requests, use the simplified payment flow
+                        onNavigate('payment-flow', {
+                          paymentRequest: {
+                            id: `upcoming-${payment.id}`,
+                            amount: payment.amount,
+                            description: payment.title,
+                            recipient: payment.organizer.name,
+                            dueDate: new Date(Date.now() + 24 * 60 * 60 * 1000).toISOString()
+                          }
+                        });
+                      }
+                    }}
+                  >
+                    {payment.status === 'overdue' ? 'Pay Overdue' : payment.status === 'due_soon' ? 'Pay Now' : 'Pay'}
+                  </Button>
                 </div>
               </div>
-              <div className="text-right space-y-2">
-                <p className="font-medium">{formatCurrencyForRegion(appSettings.region, payment.amount)}</p>
-                <Badge className={`${getStatusColor(payment.status)} text-xs flex items-center gap-1`}>
-                  {getStatusIcon(payment.status)}
-                  Due {payment.dueDate}
-                </Badge>
-                <Button
-                  size="sm"
-                  variant={payment.status === 'overdue' || payment.status === 'due_soon' ? 'default' : 'outline'}
-                  className="w-full"
-                  onClick={(e) => {
-                    e.stopPropagation();
-                    if (payment.type === 'bill_split' && payment.billSplitId) {
-                      onNavigate('pay-bill', { billId: payment.billSplitId });
-                    } else {
-                      // For direct money requests, use the simplified payment flow
-                      onNavigate('payment-flow', {
-                        paymentRequest: {
-                          id: `upcoming-${payment.id}`,
-                          amount: payment.amount,
-                          description: payment.title,
-                          recipient: payment.organizer.name,
-                          dueDate: new Date(Date.now() + 24 * 60 * 60 * 1000).toISOString()
-                        }
-                      });
-                    }
-                  }}
-                >
-                  {payment.status === 'overdue' ? 'Pay Overdue' : payment.status === 'due_soon' ? 'Pay Now' : 'Pay'}
-                </Button>
-              </div>
-            </div>
-          </Card>
-        ))}
+            </Card>
+          );
+        })}
       </div>
     </div>
   );

--- a/utils/formatDueDate.test.ts
+++ b/utils/formatDueDate.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { vi } from 'vitest';
+import { formatDueDate } from './formatDueDate';
+
+describe('formatDueDate', () => {
+  const baseDate = new Date('2025-01-15T12:00:00Z');
+
+  beforeAll(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(baseDate);
+  });
+
+  afterAll(() => {
+    vi.useRealTimers();
+  });
+
+  it('returns Today for the current date', () => {
+    expect(formatDueDate('2025-01-15T09:00:00Z')).toBe('Today');
+  });
+
+  it('returns Tomorrow for the next day', () => {
+    expect(formatDueDate('2025-01-16T09:00:00Z')).toBe('Tomorrow');
+  });
+
+  it('returns relative phrasing for upcoming dates', () => {
+    expect(formatDueDate('2025-01-18T00:00:00Z')).toBe('in 3 days');
+  });
+
+  it('returns Overdue for past dates within a day', () => {
+    expect(formatDueDate('2025-01-14T23:00:00Z')).toBe('Overdue');
+  });
+
+  it('returns Overdue by n days for older past dates', () => {
+    expect(formatDueDate('2025-01-10T12:00:00Z')).toBe('Overdue by 5 days');
+  });
+
+  it('returns empty string for invalid input', () => {
+    expect(formatDueDate('not-a-real-date')).toBe('');
+    expect(formatDueDate('')).toBe('');
+  });
+});

--- a/utils/formatDueDate.ts
+++ b/utils/formatDueDate.ts
@@ -1,0 +1,44 @@
+const MS_IN_DAY = 24 * 60 * 60 * 1000;
+
+const startOfDay = (date: Date) => {
+  const start = new Date(date);
+  start.setHours(0, 0, 0, 0);
+  return start;
+};
+
+export function formatDueDate(isoDate: string): string {
+  if (!isoDate) {
+    return '';
+  }
+
+  const dueDate = new Date(isoDate);
+
+  if (Number.isNaN(dueDate.getTime())) {
+    return '';
+  }
+
+  const today = new Date();
+  const diffInDays = Math.round(
+    (startOfDay(dueDate).getTime() - startOfDay(today).getTime()) / MS_IN_DAY
+  );
+
+  if (diffInDays === 0) {
+    return 'Today';
+  }
+
+  if (diffInDays === 1) {
+    return 'Tomorrow';
+  }
+
+  if (diffInDays > 1) {
+    return `in ${diffInDays} days`;
+  }
+
+  const daysOverdue = Math.abs(diffInDays);
+
+  if (daysOverdue === 1) {
+    return 'Overdue';
+  }
+
+  return `Overdue by ${daysOverdue} days`;
+}


### PR DESCRIPTION
## Summary
- add a formatDueDate utility that maps ISO timestamps to friendly due phrases with unit tests
- update upcoming payments components to display the friendly due text instead of raw ISO strings

## Testing
- npm test *(fails: existing suite requires services like redis/bull and additional providers)*

------
https://chatgpt.com/codex/tasks/task_e_68ca8c0e83d483239703514436e35273