### PR TITLE
Format bill split due dates for sharing

### DIFF
--- a/components/SHARING_SYSTEM_DOCS.md
+++ b/components/SHARING_SYSTEM_DOCS.md
@@ -87,7 +87,7 @@ interface ShareData {
   amount: number;
   description?: string;
   participantNames?: string[];
-  dueDate?: string;
+  dueDate?: string; // Pass a user-friendly string; ISO dates are formatted automatically
   status?: string;
   groupName?: string;
   paymentMethod?: string;
@@ -188,6 +188,7 @@ import { ShareUtils } from './ShareUtils';
 1. **Include deep links** for better user experience
 2. **Provide meaningful descriptions** for context
 3. **Format amounts** according to user's region
+4. **Normalize due dates** into user-facing strings before sharing
 
 ### Error Handling
 

--- a/components/ShareUtils.test.ts
+++ b/components/ShareUtils.test.ts
@@ -1,0 +1,48 @@
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
+import { generateShareText } from './ShareUtils';
+
+describe('generateShareText', () => {
+  const formatAmount = (n: number) => `$${n.toFixed(2)}`;
+  const userProfile = { name: 'Alex' };
+
+  beforeAll(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2025-01-15T10:00:00Z'));
+  });
+
+  afterAll(() => {
+    vi.useRealTimers();
+  });
+
+  it('formats ISO due dates into relative text', () => {
+    const shareText = generateShareText(
+      {
+        type: 'bill_split',
+        title: 'Team Lunch',
+        amount: 48.5,
+        participantNames: ['Alex', 'Sam'],
+        dueDate: '2025-01-15T09:00:00Z'
+      },
+      formatAmount,
+      userProfile
+    );
+
+    expect(shareText).toContain('📅 Due: Today');
+  });
+
+  it('preserves pre-formatted due date strings', () => {
+    const shareText = generateShareText(
+      {
+        type: 'bill_split',
+        title: 'Weekend Trip',
+        amount: 120,
+        participantNames: ['Alex', 'Sam'],
+        dueDate: 'This weekend'
+      },
+      formatAmount,
+      userProfile
+    );
+
+    expect(shareText).toContain('📅 Due: This weekend');
+  });
+});

--- a/components/ShareUtils.tsx
+++ b/components/ShareUtils.tsx
@@ -30,7 +30,7 @@ export function generateShareText(
 ) {
   const { type, title, amount, description, participantNames, dueDate, status, groupName } = shareData;
   const formattedAmount = formatAmount(amount);
-  const formattedDueDate = dueDate ? formatDueDate(dueDate) : '';
+  const formattedDueDate = dueDate ? (formatDueDate(dueDate) || dueDate) : '';
   
   switch (type) {
     case 'bill_split':

--- a/components/SimpleShareUtils.tsx
+++ b/components/SimpleShareUtils.tsx
@@ -42,7 +42,7 @@ export function SimpleShareUtils({ shareData, onNavigate }: SimpleShareUtilsProp
   const generateShareText = () => {
     const { type, title, amount, description, participantNames, dueDate, status, groupName } = shareData;
     const formattedAmount = fmt(amount);
-    const formattedDueDate = dueDate ? formatDueDate(dueDate) : '';
+    const formattedDueDate = dueDate ? (formatDueDate(dueDate) || dueDate) : '';
     
     switch (type) {
       case 'bill_split':

--- a/components/SocialSharingUtils.tsx
+++ b/components/SocialSharingUtils.tsx
@@ -40,7 +40,7 @@ export function SocialSharingUtils({ shareData, onNavigate }: SocialSharingUtils
   const generateShareText = () => {
     const { type, title, amount, description, participantNames, dueDate, status, groupName } = shareData;
     const formattedAmount = fmt(amount);
-    const formattedDueDate = dueDate ? formatDueDate(dueDate) : '';
+    const formattedDueDate = dueDate ? (formatDueDate(dueDate) || dueDate) : '';
     
     switch (type) {
       case 'bill_split':


### PR DESCRIPTION
## Summary
- format the bill split details date with a helper that reuses formatDueDate and reuse the string in share data
- allow sharing utilities to fall back to preformatted due dates and update docs plus add coverage for the new behavior

## Testing
- npm test *(fails: existing suite has numerous unrelated failures)*
- npx vitest run components/ShareUtils.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68ca942684f88323815ee753dc36e8be