### PR TITLE
Format bill dates in bill views

### DIFF
--- a/components/BillPaymentScreen.tsx
+++ b/components/BillPaymentScreen.tsx
@@ -9,6 +9,7 @@ import { toast } from 'sonner';
 import { useUserProfile } from './UserProfileContext';
 import { requiresRoutingNumber, getBankIdentifierLabel, formatBankAccountForRegion, formatCurrencyForRegion } from '../utils/regions';
 import { apiClient } from '../utils/apiClient';
+import { formatBillDate } from '../utils/formatBillDate';
 
 interface BillPaymentScreenProps {
   billId: string | null;
@@ -87,6 +88,8 @@ export function BillPaymentScreen({ billId, onNavigate }: BillPaymentScreenProps
       </div>
     );
   }
+
+  const formattedBillDate = formatBillDate(bill.date);
 
   const copyPaymentDetails = async () => {
     const { paymentMethod } = bill;
@@ -359,7 +362,10 @@ export function BillPaymentScreen({ billId, onNavigate }: BillPaymentScreenProps
             
             <div>
               <p className="text-sm text-muted-foreground mb-1">Created by</p>
-              <p className="text-sm">{bill.createdBy} • {bill.date}</p>
+              <p className="text-sm">
+                {bill.createdBy}
+                {formattedBillDate ? ` • ${formattedBillDate}` : ''}
+              </p>
             </div>
 
             {bill.note && (

--- a/components/BillSplitDetailsScreen.tsx
+++ b/components/BillSplitDetailsScreen.tsx
@@ -14,7 +14,7 @@ import { ShareSheet } from './ui/share-sheet';
 import { createDeepLink } from './ShareUtils';
 import { PageLoading } from './ui/loading';
 import { apiClient } from '../utils/apiClient';
-import { formatDueDate } from '../utils/formatDueDate';
+import { formatBillDate } from '../utils/formatBillDate';
 
 interface BillSplitDetailsScreenProps {
   billSplitId: string | null;
@@ -64,29 +64,6 @@ interface BillSplit {
 }
 
 const billSplitCache = new Map<string, BillSplit>();
-
-const formatBillSplitDate = (dateString?: string) => {
-  if (!dateString) {
-    return '';
-  }
-
-  const relative = formatDueDate(dateString);
-  if (relative) {
-    return relative;
-  }
-
-  const parsed = new Date(dateString);
-  if (Number.isNaN(parsed.getTime())) {
-    return '';
-  }
-
-  const now = new Date();
-  return parsed.toLocaleDateString(undefined, {
-    month: 'short',
-    day: 'numeric',
-    year: parsed.getFullYear() === now.getFullYear() ? undefined : 'numeric',
-  });
-};
 
 async function getBillSplit(id: string): Promise<BillSplit> {
   const data = await apiClient(`/bill-splits/${id}`);
@@ -241,7 +218,7 @@ export function BillSplitDetailsScreen({ billSplitId, onNavigate }: BillSplitDet
   const paidParticipants = billSplit.participants.filter(p => p.status === 'paid');
   const totalPaid = paidParticipants.reduce((sum, p) => sum + p.amount, 0);
   const progressPercentage = (totalPaid / billSplit.totalAmount) * 100;
-  const formattedBillDate = formatBillSplitDate(billSplit.date);
+  const formattedBillDate = formatBillDate(billSplit.date);
   const detailsCardDate = formattedBillDate || '—';
 
   const handleEdit = () => {

--- a/components/BillsScreen.tsx
+++ b/components/BillsScreen.tsx
@@ -11,6 +11,7 @@ import { toast } from 'sonner';
 import { useBillSplits } from '../hooks/useBillSplits';
 import { useUserProfile } from './UserProfileContext';
 import { formatCurrencyForRegion } from '../utils/regions';
+import { formatBillDate } from '../utils/formatBillDate';
 
 interface BillsScreenProps {
   onNavigate: (tab: string, data?: any) => void;
@@ -120,143 +121,147 @@ export function BillsScreen({ onNavigate, groupId }: BillsScreenProps) {
 
         {/* Bills List */}
         <div className="space-y-4">
-          {filteredBills.map((bill) => (
-            <Card 
-              key={bill.id} 
-              className="p-4 cursor-pointer hover:bg-muted/50 transition-colors"
-              onClick={() => onNavigate('bill-split-details', { billSplitId: bill.id })}
-            >
-            <div className="space-y-3">
-              {/* Header */}
-              <div className="flex items-center justify-between">
-                <div>
-                  <h3 className="font-medium">{bill.title}</h3>
-                  {/*
-                  <p className="text-sm text-muted-foreground">
-                    Split by {bill.createdBy} • {bill.date}
-                  </p>
-                  */}
-                  <p className="text-sm text-muted-foreground">
-                    Split by {bill.createdBy} • {bill.date}
-                  </p>
-                </div>
-                <Badge
-                  variant="secondary"
-                  className={`${getStatusColor(bill.status)} flex items-center gap-1`}
+          {filteredBills.map((bill) => {
+            const formattedBillDate = formatBillDate(bill.date);
+            return (
+              <Card
+                key={bill.id}
+                className="p-4 cursor-pointer hover:bg-muted/50 transition-colors"
+                onClick={() => onNavigate('bill-split-details', { billSplitId: bill.id })}
                 >
-                  {getStatusIcon(bill.status)}
-                  {bill.status}
-                </Badge>
-              </div>
-
-              {/* Amount Info */}
-              <div className="flex items-center justify-between">
-                <div>
-                  <p className="text-sm text-muted-foreground">Your share</p>
-                  <p className="font-medium">{fmt(bill.yourShare)}</p>
-                </div>
-                <div className="text-right">
-                  <p className="text-sm text-muted-foreground">Total</p>
-                  <p className="font-medium">{fmt(bill.totalAmount)}</p>
-                </div>
-              </div>
-
-              {/* Participants */}
-              <div>
-                <div className="flex items-center justify-between mb-2">
-                  <p className="text-sm text-muted-foreground">Participants</p>
-                  <p className="text-sm text-muted-foreground">
-                    {bill.participants.filter(p => p.paid).length} of {bill.participants.length} paid
-                  </p>
-                </div>
-                <div className="flex -space-x-2">
-                  {bill.participants.map((participant, index) => (
-                    <div key={index} className="relative">
-                      <Avatar className={`h-8 w-8 border-2 ${participant.paid ? 'border-green-500' : 'border-yellow-500'}`}>
-                        <AvatarFallback className="text-xs">
-                          {participant.name.split(' ').map(n => n[0]).join('')}
-                        </AvatarFallback>
-                      </Avatar>
-                      {participant.paid && (
-                        <div className="absolute -top-1 -right-1 bg-green-500 rounded-full p-0.5">
-                          <CheckCircle className="h-3 w-3 text-white" />
-                        </div>
-                      )}
+                <div className="space-y-3">
+                  {/* Header */}
+                  <div className="flex items-center justify-between">
+                    <div>
+                      <h3 className="font-medium">{bill.title}</h3>
+                      {/*
+                      <p className="text-sm text-muted-foreground">
+                        Split by {bill.createdBy} • {bill.date}
+                      </p>
+                      */}
+                      <p className="text-sm text-muted-foreground">
+                        Split by {bill.createdBy}
+                        {formattedBillDate ? ` • ${formattedBillDate}` : ''}
+                      </p>
                     </div>
-                  ))}
+                  <Badge
+                    variant="secondary"
+                    className={`${getStatusColor(bill.status)} flex items-center gap-1`}
+                  >
+                    {getStatusIcon(bill.status)}
+                    {bill.status}
+                  </Badge>
+                </div>
+  
+                {/* Amount Info */}
+                <div className="flex items-center justify-between">
+                  <div>
+                    <p className="text-sm text-muted-foreground">Your share</p>
+                    <p className="font-medium">{fmt(bill.yourShare)}</p>
+                  </div>
+                  <div className="text-right">
+                    <p className="text-sm text-muted-foreground">Total</p>
+                    <p className="font-medium">{fmt(bill.totalAmount)}</p>
+                  </div>
+                </div>
+  
+                {/* Participants */}
+                <div>
+                  <div className="flex items-center justify-between mb-2">
+                    <p className="text-sm text-muted-foreground">Participants</p>
+                    <p className="text-sm text-muted-foreground">
+                      {bill.participants.filter(p => p.paid).length} of {bill.participants.length} paid
+                    </p>
+                  </div>
+                  <div className="flex -space-x-2">
+                    {bill.participants.map((participant, index) => (
+                      <div key={index} className="relative">
+                        <Avatar className={`h-8 w-8 border-2 ${participant.paid ? 'border-green-500' : 'border-yellow-500'}`}>
+                          <AvatarFallback className="text-xs">
+                            {participant.name.split(' ').map(n => n[0]).join('')}
+                          </AvatarFallback>
+                        </Avatar>
+                        {participant.paid && (
+                          <div className="absolute -top-1 -right-1 bg-green-500 rounded-full p-0.5">
+                            <CheckCircle className="h-3 w-3 text-white" />
+                          </div>
+                        )}
+                      </div>
+                    ))}
+                  </div>
+                </div>
+  
+                {/* Actions */}
+                <div className="flex gap-2 pt-2">
+                  {bill.status === 'pending' && (
+                    <>
+                      <Button 
+                        size="sm" 
+                        className="flex-1"
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          onNavigate('pay-bill', { billId: bill.id });
+                        }}
+                      >
+                        Pay {fmt(bill.yourShare)}
+                      </Button>
+                      <Button 
+                        size="sm" 
+                        variant="outline"
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          const unpaidParticipants = bill.participants.filter(p => !p.paid && p.name !== 'You');
+                          if (unpaidParticipants.length > 0) {
+                            onNavigate('send-reminder', {
+                              billSplitId: bill.id,
+                              paymentType: 'bill-split'
+                            });
+                          } else {
+                            toast.info('All participants have already paid');
+                          }
+                        }}
+                      >
+                        Remind Others
+                      </Button>
+                    </>
+                  )}
+  
+                  {/* Reorder/Reuse buttons - always show for completed bills, show for pending if you're the creator */}
+                  {(bill.status === 'completed' || bill.createdBy === 'You') && (
+                    <>
+                      <Button
+                        size="sm"
+                        variant="outline"
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          handleReorderSplit(bill);
+                        }}
+                        className="flex items-center gap-1"
+                        title="Create identical split with same participants and amounts"
+                      >
+                        <RotateCcw className="h-3 w-3" />
+                        Reorder
+                      </Button>
+                      <Button
+                        size="sm"
+                        variant="outline"
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          handleReuseSplit(bill);
+                        }}
+                        className="flex items-center gap-1"
+                        title="Use as template - you can modify before creating"
+                      >
+                        <Copy className="h-3 w-3" />
+                        Reuse
+                      </Button>
+                    </>
+                  )}
                 </div>
               </div>
-
-              {/* Actions */}
-              <div className="flex gap-2 pt-2">
-                {bill.status === 'pending' && (
-                  <>
-                    <Button 
-                      size="sm" 
-                      className="flex-1"
-                      onClick={(e) => {
-                        e.stopPropagation();
-                        onNavigate('pay-bill', { billId: bill.id });
-                      }}
-                    >
-                      Pay {fmt(bill.yourShare)}
-                    </Button>
-                    <Button 
-                      size="sm" 
-                      variant="outline"
-                      onClick={(e) => {
-                        e.stopPropagation();
-                        const unpaidParticipants = bill.participants.filter(p => !p.paid && p.name !== 'You');
-                        if (unpaidParticipants.length > 0) {
-                          onNavigate('send-reminder', {
-                            billSplitId: bill.id,
-                            paymentType: 'bill-split'
-                          });
-                        } else {
-                          toast.info('All participants have already paid');
-                        }
-                      }}
-                    >
-                      Remind Others
-                    </Button>
-                  </>
-                )}
-
-                {/* Reorder/Reuse buttons - always show for completed bills, show for pending if you're the creator */}
-                {(bill.status === 'completed' || bill.createdBy === 'You') && (
-                  <>
-                    <Button
-                      size="sm"
-                      variant="outline"
-                      onClick={(e) => {
-                        e.stopPropagation();
-                        handleReorderSplit(bill);
-                      }}
-                      className="flex items-center gap-1"
-                      title="Create identical split with same participants and amounts"
-                    >
-                      <RotateCcw className="h-3 w-3" />
-                      Reorder
-                    </Button>
-                    <Button
-                      size="sm"
-                      variant="outline"
-                      onClick={(e) => {
-                        e.stopPropagation();
-                        handleReuseSplit(bill);
-                      }}
-                      className="flex items-center gap-1"
-                      title="Use as template - you can modify before creating"
-                    >
-                      <Copy className="h-3 w-3" />
-                      Reuse
-                    </Button>
-                  </>
-                )}
-              </div>
-            </div>
-            </Card>
-          ))}
+              </Card>
+            );
+          })}
         </div>
 
         {filteredBills.length === 0 && (

--- a/mocks/bill-splits.ts
+++ b/mocks/bill-splits.ts
@@ -1,7 +1,9 @@
 // Mock handler for /bill-splits/* endpoints
+import { formatBillDate } from '../utils/formatBillDate';
 
 function makeBillSplit(id: string) {
   const createdAt = new Date().toISOString();
+  const friendlyDate = formatBillDate(createdAt);
   return {
     id,
     title: 'Mock Group Dinner',
@@ -15,6 +17,7 @@ function makeBillSplit(id: string) {
     ],
     createdBy: 'Alice',
     date: createdAt,
+    friendlyDate,
     paymentMethod: {
       type: 'bank',
       bankName: 'Mock Bank',

--- a/utils/formatBillDate.test.ts
+++ b/utils/formatBillDate.test.ts
@@ -1,0 +1,50 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const FIXED_NOW = new Date('2025-01-15T09:00:00Z');
+
+describe('formatBillDate', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(FIXED_NOW);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.resetModules();
+    vi.unmock('./formatDueDate');
+  });
+
+  it('returns a relative label when the due date is today', async () => {
+    const { formatBillDate } = await import('./formatBillDate');
+    expect(formatBillDate('2025-01-15T09:00:00Z')).toBe('Today');
+  });
+
+  it('returns a relative label when the due date is tomorrow', async () => {
+    const { formatBillDate } = await import('./formatBillDate');
+    expect(formatBillDate('2025-01-16T09:00:00Z')).toBe('Tomorrow');
+  });
+
+  it('returns empty string for invalid values', async () => {
+    const { formatBillDate } = await import('./formatBillDate');
+    expect(formatBillDate('not-a-real-date')).toBe('');
+    expect(formatBillDate('')).toBe('');
+  });
+});
+
+describe('formatBillDate fallback formatting', () => {
+  afterEach(() => {
+    vi.resetModules();
+    vi.unmock('./formatDueDate');
+  });
+
+  it('uses locale formatting when no relative label is available', async () => {
+    const mockRelative = vi.fn(() => '');
+    vi.doMock('./formatDueDate', () => ({ formatDueDate: mockRelative }));
+    const { formatBillDate } = await import('./formatBillDate');
+
+    const localeSpy = vi.spyOn(Date.prototype, 'toLocaleDateString').mockReturnValue('Jan 10');
+    expect(formatBillDate('2025-01-10T00:00:00Z')).toBe('Jan 10');
+    expect(mockRelative).toHaveBeenCalledWith('2025-01-10T00:00:00Z');
+    localeSpy.mockRestore();
+  });
+});

--- a/utils/formatBillDate.ts
+++ b/utils/formatBillDate.ts
@@ -1,0 +1,24 @@
+import { formatDueDate } from './formatDueDate';
+
+export function formatBillDate(dateString?: string): string {
+  if (!dateString) {
+    return '';
+  }
+
+  const relative = formatDueDate(dateString);
+  if (relative) {
+    return relative;
+  }
+
+  const parsed = new Date(dateString);
+  if (Number.isNaN(parsed.getTime())) {
+    return '';
+  }
+
+  const now = new Date();
+  return parsed.toLocaleDateString(undefined, {
+    month: 'short',
+    day: 'numeric',
+    year: parsed.getFullYear() === now.getFullYear() ? undefined : 'numeric',
+  });
+}


### PR DESCRIPTION
## Summary
- extract the bill date formatter into a shared util so friendly labels can be reused
- render formatted bill dates across split list, payment, and detail screens while handling missing values
- add tests and mock updates to cover the new formatter output

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68caa8b153e48323b7753a4853b2222b