### PR TITLE
Handle phone normalization without duplicate prefixes

### DIFF
--- a/components/RegisterScreen.tsx
+++ b/components/RegisterScreen.tsx
@@ -6,6 +6,7 @@ import { Checkbox } from './ui/checkbox';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from './ui/select';
 import { Eye, EyeOff, Mail, Lock, User, ArrowLeft } from 'lucide-react';
 import { useUserProfile } from './UserProfileContext';
+import { normalizePhoneNumber } from '../utils/phone';
 
 interface RegisterScreenProps {
   onRegister: (data: any) => Promise<void> | void;
@@ -78,11 +79,13 @@ export function RegisterScreen({ onRegister, onShowLogin }: RegisterScreenProps)
   const [errors, setErrors] = useState<Record<string, string>>({});
 
   const selectedCountry = countryOptions.find(c => c.code === formData.country);
+  const exampleLocalNumber = selectedCountry?.code === 'NG'
+    ? '8012345678'
+    : selectedCountry?.code === 'GB'
+      ? '7123456789'
+      : '5551234567';
 
-  const formatPhone = () => {
-    const digits = formData.phone.replace(/\D/g, '').replace(/^0+/, '');
-    return selectedCountry ? `${selectedCountry.phonePrefix}${digits}` : `+${digits}`;
-  };
+  const formatPhone = () => normalizePhoneNumber(formData.phone, selectedCountry?.phonePrefix);
 
   const validateForm = () => {
     const newErrors: Record<string, string> = {};
@@ -263,14 +266,14 @@ export function RegisterScreen({ onRegister, onShowLogin }: RegisterScreenProps)
                 <Input
                   id="phone"
                   type="tel"
-                  placeholder={selectedCountry ? `${selectedCountry.phonePrefix}8012345678` : '+15551234567'}
+                  placeholder={selectedCountry ? `e.g. ${exampleLocalNumber} or ${selectedCountry.phonePrefix}${exampleLocalNumber}` : 'e.g. +15551234567'}
                   value={formData.phone}
                   onChange={(e) => updateFormData('phone', e.target.value)}
                   className="h-10"
                 />
                 {selectedCountry && (
                   <p className="text-xs text-muted-foreground">
-                    Enter number in international format, e.g. {selectedCountry.phonePrefix}8012345678
+                    Enter your number with or without the country code. Examples: {exampleLocalNumber}, {selectedCountry.phonePrefix}{exampleLocalNumber}
                   </p>
                 )}
                 {errors.phone && <p className="text-xs text-destructive">{errors.phone}</p>}

--- a/utils/phone.test.ts
+++ b/utils/phone.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest';
+import { normalizePhoneNumber } from './phone';
+
+describe('normalizePhoneNumber', () => {
+  it('returns empty string when input has no digits', () => {
+    expect(normalizePhoneNumber('', '+234')).toBe('');
+  });
+
+  it('removes leading zeros and prepends selected country code for local numbers', () => {
+    expect(normalizePhoneNumber('0801 234 5678', '+234')).toBe('+2348012345678');
+  });
+
+  it('keeps pasted E.164 numbers without duplicating the country code', () => {
+    expect(normalizePhoneNumber('+2348012345678', '+234')).toBe('+2348012345678');
+  });
+
+  it('treats numbers that start with the prefix digits as already normalized', () => {
+    expect(normalizePhoneNumber('2348012345678', '+234')).toBe('+2348012345678');
+  });
+
+  it('falls back to returning an international format when no country prefix is provided', () => {
+    expect(normalizePhoneNumber('15551234567')).toBe('+15551234567');
+  });
+});

--- a/utils/phone.ts
+++ b/utils/phone.ts
@@ -1,0 +1,20 @@
+export const normalizePhoneNumber = (input: string, countryPrefix?: string): string => {
+  const digitsOnly = input.replace(/\D/g, '');
+  const prefixDigits = countryPrefix?.replace(/\D/g, '') ?? '';
+
+  if (!digitsOnly) {
+    return '';
+  }
+
+  if (prefixDigits && digitsOnly.startsWith(prefixDigits)) {
+    return `+${digitsOnly}`;
+  }
+
+  const nationalDigits = digitsOnly.replace(/^0+/, '');
+
+  if (!nationalDigits) {
+    return '';
+  }
+
+  return prefixDigits ? `+${prefixDigits}${nationalDigits}` : `+${nationalDigits}`;
+};


### PR DESCRIPTION
## Summary
- add a shared phone normalization helper and use it in the register and login flows to avoid duplicating country codes
- update the phone placeholders and helper copy so users can enter local numbers or paste full E.164 values confidently
- add unit coverage for the normalization logic and ensure OTP service tests pass with the new behavior

## Testing
- npx vitest run utils/phone.test.ts services/auth.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68dfc4486bec8323b3b8a92250ace5d1