### PR TITLE
Include friend phone numbers in API responses

### DIFF
--- a/hooks/useFriends.test.ts
+++ b/hooks/useFriends.test.ts
@@ -31,9 +31,9 @@ describe('fetchFriends', () => {
   it('reuses inflight promise and filters inactive statuses', async () => {
     const response = {
       friends: [
-        { id: '1', name: 'Active Alice', status: 'active' },
-        { id: '2', name: 'Pending Pam', status: 'pending' },
-        { id: '3', name: 'Blocked Ben', status: 'blocked' },
+        { id: '1', name: 'Active Alice', status: 'active', phoneNumber: '+11111111111' },
+        { id: '2', name: 'Pending Pam', status: 'pending', phoneNumber: '+12222222222' },
+        { id: '3', name: 'Blocked Ben', status: 'blocked', phoneNumber: '+13333333333' },
       ],
     };
 
@@ -47,7 +47,7 @@ describe('fetchFriends', () => {
     const [friends, sameFriends] = await Promise.all([firstCall, secondCall]);
 
     const expected: Friend[] = [
-      { id: '1', name: 'Active Alice', avatar: undefined, phoneNumber: undefined, status: 'active' },
+      { id: '1', name: 'Active Alice', avatar: undefined, phoneNumber: '+11111111111', status: 'active' },
     ];
 
     expect(friends).toEqual(expected);
@@ -60,7 +60,7 @@ describe('fetchFriends', () => {
 
     apiClientMock.mockResolvedValueOnce({
       friends: [
-        { id: '1', name: 'Cached Casey', status: 'active' },
+        { id: '1', name: 'Cached Casey', status: 'active', phoneNumber: '+14444444444' },
       ],
     });
 
@@ -75,7 +75,7 @@ describe('fetchFriends', () => {
 
     apiClientMock.mockResolvedValueOnce({
       friends: [
-        { id: '2', name: 'Fresh Frankie', status: 'active' },
+        { id: '2', name: 'Fresh Frankie', status: 'active', phoneNumber: '+15555555555' },
       ],
     });
 
@@ -87,7 +87,7 @@ describe('fetchFriends', () => {
     const refreshed = await fetchFriends();
 
     const expected: Friend[] = [
-      { id: '2', name: 'Fresh Frankie', avatar: undefined, phoneNumber: undefined, status: 'active' },
+      { id: '2', name: 'Fresh Frankie', avatar: undefined, phoneNumber: '+15555555555', status: 'active' },
     ];
 
     expect(refreshed).toEqual(expected);
@@ -101,7 +101,7 @@ describe('useFriends', () => {
   it('returns cached data immediately', async () => {
     apiClientMock.mockResolvedValueOnce({
       friends: [
-        { id: '1', name: 'Cached Carly', status: 'active' },
+        { id: '1', name: 'Cached Carly', status: 'active', phoneNumber: '+16666666666' },
       ],
     });
 
@@ -120,7 +120,7 @@ describe('useFriends', () => {
   it('fetches friends when cache is empty', async () => {
     apiClientMock.mockResolvedValueOnce({
       friends: [
-        { id: '1', name: 'Fetched Fiona', status: 'active' },
+        { id: '1', name: 'Fetched Fiona', status: 'active', phoneNumber: '+17777777777' },
       ],
     });
 
@@ -132,7 +132,7 @@ describe('useFriends', () => {
     await waitFor(() => expect(result.current.loading).toBe(false));
 
     const expected: Friend[] = [
-      { id: '1', name: 'Fetched Fiona', avatar: undefined, phoneNumber: undefined, status: 'active' },
+      { id: '1', name: 'Fetched Fiona', avatar: undefined, phoneNumber: '+17777777777', status: 'active' },
     ];
 
     expect(result.current.friends).toEqual(expected);

--- a/server/routes/friends.js
+++ b/server/routes/friends.js
@@ -127,8 +127,8 @@ router.get('/search', async (req, res) => {
         ]
       },
       include: {
-        user1: { select: { id: true, name: true, email: true, avatar: true } },
-        user2: { select: { id: true, name: true, email: true, avatar: true } }
+        user1: { select: { id: true, name: true, email: true, avatar: true, phone: true } },
+        user2: { select: { id: true, name: true, email: true, avatar: true, phone: true } }
       }
     })
 


### PR DESCRIPTION
## Summary
- ensure friend search responses include phone data in Prisma selects
- populate test fixtures with phone numbers and assert they surface in API responses
- update friend hook unit tests to cover propagation of phone numbers from the API

## Testing
- `npx vitest run server/routes/friends.test.js hooks/useFriends.test.ts` *(fails: prisma migrate deploy requires Postgres server at localhost:5432)*

------
https://chatgpt.com/codex/tasks/task_e_68e633bff0a08323b0188515cbe6efff